### PR TITLE
Add Service manager functions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -265,6 +265,131 @@ const
     SQL_NULL      = 32766; // >= 2.5
 
 /***********************/
+/*   ISC Services      */
+/***********************/
+const
+	isc_action_svc_backup = 1, /* Starts database backup process on the server	*/
+	isc_action_svc_restore = 2, /* Starts database restore process on the server */
+	isc_action_svc_repair = 3, /* Starts database repair process on the server	*/
+	isc_action_svc_add_user = 4, /* Adds	a new user to the security database	*/
+	isc_action_svc_delete_user = 5, /* Deletes a user record from the security database	*/
+	isc_action_svc_modify_user = 6, /* Modifies	a user record in the security database */
+	isc_action_svc_display_user = 7, /* Displays	a user record from the security	database */
+	isc_action_svc_properties = 8, /* Sets	database properties	*/
+	isc_action_svc_add_license = 9, /* Adds	a license to the license file */
+	isc_action_svc_remove_license = 10, /* Removes a license from the license file */
+	isc_action_svc_db_stats = 11, /* Retrieves database statistics */
+	isc_action_svc_get_ib_log = 12; /* Retrieves the InterBase log file	from the server	*/
+
+const
+	isc_info_svc_svr_db_info = 50, /* Retrieves the number	of attachments and databases */
+	isc_info_svc_get_license = 51, /* Retrieves all license keys and IDs from the license file	*/
+	isc_info_svc_get_license_mask = 52, /* Retrieves a bitmask representing	licensed options on	the	server */
+	isc_info_svc_get_config = 53, /* Retrieves the parameters	and	values for IB_CONFIG */
+	isc_info_svc_version = 54, /* Retrieves the version of	the	services manager */
+	isc_info_svc_server_version = 55, /* Retrieves the version of	the	InterBase server */
+	isc_info_svc_implementation = 56, /* Retrieves the implementation	of the InterBase server	*/
+	isc_info_svc_capabilities = 57, /* Retrieves a bitmask representing	the	server's capabilities */
+	isc_info_svc_user_dbpath = 58, /* Retrieves the path to the security database in use by the server	*/
+	isc_info_svc_get_env = 59, /* Retrieves the setting of	$INTERBASE */
+	isc_info_svc_get_env_lock = 60, /* Retrieves the setting of	$INTERBASE_LCK */
+	isc_info_svc_get_env_msg = 61, /* Retrieves the setting of	$INTERBASE_MSG */
+	isc_info_svc_line = 62, /* Retrieves 1 line	of service output per call */
+	isc_info_svc_to_eof = 63, /* Retrieves as much of	the	server output as will fit in the supplied buffer */
+	isc_info_svc_timeout = 64, /* Sets	/ signifies	a timeout value	for	reading	service	information	*/
+	isc_info_svc_get_licensed_users = 65, /* Retrieves the number	of users licensed for accessing	the	server */
+	isc_info_svc_limbo_trans = 66, /* Retrieve	the	limbo transactions */
+	isc_info_svc_running = 67, /* Checks to see if	a service is running on	an attachment */
+	isc_info_svc_get_users = 68; /* Returns the user	information	from isc_action_svc_display_users */
+
+/* Services Properties */	
+const
+	isc_spb_prp_page_buffers = 5,
+	isc_spb_prp_sweep_interval = 6,
+	isc_spb_prp_shutdown_db = 7,
+	isc_spb_prp_deny_new_attachments = 9,
+	isc_spb_prp_deny_new_transactions = 10,
+	isc_spb_prp_reserve_space = 11,
+	isc_spb_prp_write_mode = 12,
+	isc_spb_prp_access_mode = 13,
+	isc_spb_prp_set_sql_dialect = 14,
+
+		// WRITE_MODE_PARAMETERS
+	isc_spb_prp_wm_async = 37,
+	isc_spb_prp_wm_sync = 38,
+
+		// ACCESS_MODE_PARAMETERS
+	isc_spb_prp_am_readonly = 39,
+	isc_spb_prp_am_readwrite = 40,
+
+		// RESERVE_SPACE_PARAMETERS
+	isc_spb_prp_res_use_full = 35,
+	isc_spb_prp_res = 36,
+
+		// Option Flags		
+	isc_spb_prp_activate = 0x0100,
+	isc_spb_prp_db_online = 0x0200;
+
+/* · Backup Service ·*/
+const
+	isc_spb_bkp_file = 5,
+	isc_spb_bkp_factor = 6,
+	isc_spb_bkp_length = 7,
+    isc_spb_bkp_ignore_checksums = 0x01,
+    isc_spb_bkp_ignore_limbo = 0x02,
+    isc_spb_bkp_metadata_only = 0x04,
+    isc_spb_bkp_no_garbage_collect = 0x08,
+    isc_spb_bkp_old_descriptions = 0x10,
+    isc_spb_bkp_non_transportable = 0x20,
+    isc_spb_bkp_convert = 0x40,
+    isc_spb_bkp_expand = 0x80,
+    isc_spb_bkp_no_triggers = 0x8000;
+
+/*	Restore Service ·*/
+const
+	isc_spb_res_buffers = 9,
+	isc_spb_res_page_size = 10,
+	isc_spb_res_length = 11,
+	isc_spb_res_access_mode = 12,
+
+	isc_spb_res_am_readonly = isc_spb_prp_am_readonly,
+	isc_spb_res_am_readwrite = isc_spb_prp_am_readwrite;
+
+/* · Repair Service ·*/
+const
+    isc_spb_rpr_commit_trans = 15,
+	isc_spb_rpr_rollback_trans = 34,
+	isc_spb_rpr_recover_two_phase = 17,
+	isc_spb_tra_id = 18,
+	isc_spb_single_tra_id = 19,
+	isc_spb_multi_tra_id = 20,
+	isc_spb_tra_state = 21,
+	isc_spb_tra_state_limbo = 22,
+	isc_spb_tra_state_commit = 23,
+	isc_spb_tra_state_rollback = 24,
+	isc_spb_tra_state_unknown = 25,
+	isc_spb_tra_host_site = 26,
+	isc_spb_tra_remote_site = 27,
+	isc_spb_tra_db_path = 28,
+	isc_spb_tra_advise = 29,
+	isc_spb_tra_advise_commit = 30,
+	isc_spb_tra_advise_rollback = 31,
+	isc_spb_tra_advise_unknown = 33;
+
+/* · Security Service ·*/
+const
+	isc_spb_sec_userid = 5,
+	isc_spb_sec_groupid = 6,
+	isc_spb_sec_username = 7,
+	isc_spb_sec_password = 8,
+	isc_spb_sec_groupname = 9,
+	isc_spb_sec_firstname = 10,
+	isc_spb_sec_middlename = 11,
+	isc_spb_sec_lastname = 12;
+
+
+
+/***********************/
 /*   ISC Error Codes   */
 /***********************/
 const
@@ -360,6 +485,23 @@ const
     isc_dpb_org_filename            = 76,
     isc_dpb_utf8_filename           = 77,
     isc_dpb_ext_call_depth          = 78;
+
+/*************************************/
+/* Services parameter block stuff    */
+/*************************************/
+const
+    isc_spb_version1 = 1,
+    isc_spb_current_version = 2,
+    isc_spb_version = isc_spb_current_version,
+    isc_spb_user_name = isc_dpb_user_name,
+    isc_spb_sys_user_name = isc_dpb_sys_user_name,
+    isc_spb_sys_user_name_enc = isc_dpb_sys_user_name_enc,
+    isc_spb_password = isc_dpb_password,
+    isc_spb_password_enc = isc_dpb_password_enc,
+    isc_spb_command_line = 105,
+    isc_spb_dbname = 106,
+    isc_spb_verbose = 107,
+    isc_spb_options = 108;
 
 /*************************************/
 /* Transaction parameter block stuff */
@@ -523,7 +665,8 @@ const
     DEFAULT_PORT = 3050,
     DEFAULT_USER = 'SYSDBA',
     DEFAULT_PASSWORD = 'masterkey',
-    DEFAULT_PAGE_SIZE = 4096;
+    DEFAULT_PAGE_SIZE = 4096,
+    DEFAULT_SVC_NAME = 'service_mgr';
 
 exports.ISOLATION_READ_UNCOMMITTED = ISOLATION_READ_UNCOMMITTED;
 exports.ISOLATION_READ_COMMITED = ISOLATION_READ_COMMITED;
@@ -1326,7 +1469,7 @@ exports.attach = function(options, callback) {
 
     var host = options.host || DEFAULT_HOST;
     var port = options.port || DEFAULT_PORT;
-
+    var manager = options.manager || false;
     var cnx = this.connection = new Connection(host, port, function(err) {
 
         if (err) {
@@ -1335,10 +1478,14 @@ exports.attach = function(options, callback) {
         }
 
         cnx.connect(options.database || options.filename, function(err) {
-            if (err)
+            if (err) {
                 doError(err, callback);
-            else
-                cnx.attach(options, callback);
+            } else {
+                if (manager)
+                    cnx.svcattach(options, callback);
+                else
+                    cnx.attach(options, callback);
+            }
         });
 
     }, options);
@@ -1397,6 +1544,135 @@ exports.attachOrCreate = function(options, callback) {
 
     }, options);
 };
+
+/***************************************
+ *
+ *   Service Manager
+ *
+ ***************************************/
+
+function ServiceManager(connection) {
+    this.connection = connection;
+    connection.svc = this;
+}
+
+ServiceManager.prototype.__proto__ = Object.create(Events.EventEmitter.prototype, {
+    constructor: {
+        value: ServiceManager,
+        enumberable: false
+    }
+});
+
+ServiceManager.prototype.detach = function(callback, force) {
+    var self = this;
+    
+    if (!force && self.connection._pending.length > 0) {
+        self.connection._detachAuto = true;
+        self.connection._detachCallback = callback;
+        return self;
+    }
+    
+    self.connection.svcdetach(function (err, obj) {
+        
+        self.connection.disconnect();
+        self.emit('detach', false);
+        
+        if (callback)
+            callback(err, obj);
+
+    }, force);
+    
+    return self;
+}
+
+ServiceManager.prototype.backup = function (options, callback) {
+    var dbpath = options.database || this.connection.options.filename || this.connection.options.database;
+    var verbose = options.verbose || false;
+    // format of bckfile {filename:'name', sizefile:''} sizefile is length of part in bytes
+    var bckfiles = options.files || null;
+    var factor = options.factor || 0; //If backing up to a physical tape device, this switch lets you specify the tape's blocking factor
+    var ignorechecksums = options.ignorechecksums || false;
+    var ignorelimbo = options.ignorelimbo || false;
+    var metadataonly = options.metadataonly || false;
+    var nogarbagecollect = options.nogarbasecollect || false;
+    var olddescriptions = options.olddescriptions || false;
+    var nontransportable = options.nontransportable || false;
+    var convert = options.convert || false;
+    var expand = options.expand || false;
+    var notriggers = options.notriggers || false;
+
+    if (dbpath == null || dbpath.length == 0) {
+        doError(new Error('No database specified'), callback);
+        return;
+    }
+    
+    if (bckfiles == null || bckfiles.length == 0) {
+        doError(new Error('No backup path specified'), callback);
+        return;
+    }
+    
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_backup);
+    blr.addString2(isc_spb_dbname, dbpath, DEFAULT_ENCODING);
+    for (var i = 0; i < bckfiles.length; i++) {
+        blr.addString2(isc_spb_bkp_file, bckfiles[i].filename, DEFAULT_ENCODING);
+        if (i != bckfiles.length - 1) // not the end, so we need to write the size of this part (gsplit)
+            blr.addString2(isc_spb_bkp_length, bckfiles[i].sizefile, DEFAULT_ENCODING);
+    }
+    if (factor) {
+        blr.addByte(isc_spb_bkp_factor);
+        blr.addInt32(factor);
+    }
+    var options = 0;
+    if (ignorechecksums) options = options | isc_spb_bkp_ignore_checksums;
+    if (ignorelimbo) options = options | isc_spb_bkp_ignore_limbo;
+    if (metadataonly) options = options | isc_spb_bkp_metadata_only;
+    if (nogarbagecollect) options = options | isc_spb_bkp_no_garbage_collect;
+    if (olddescriptions) options = options | isc_spb_bkp_old_descriptions;
+    if (nontransportable) options = options | isc_spb_bkp_non_transportable;
+    if (convert) options = options | isc_spb_bkp_convert;
+    if (expand) options = options | isc_spb_bkp_expand;
+    if (notriggers) options = options | isc_spb_bkp_no_triggers;
+    if (options) {
+        blr.addByte(isc_spb_options);
+        blr.addInt32(options);
+    }
+    if (verbose)
+        blr.addByte(isc_spb_verbose);
+
+    this.connection.svcstart(blr, callback);
+
+}
+
+ServiceManager.prototype.restore = function(options, callback) {
+
+}
+
+ServiceManager.prototype.gfix = function (options, callback) {
+
+}
+
+ServiceManager.prototype.repair = function (options, callback) {
+
+}
+
+ServiceManager.prototype.stats = function (options, callback) {
+
+}
+
+ServiceManager.prototype.log = function (options, callback) {
+
+}
+
+ServiceManager.prototype.gsec = function (options, callback) {
+
+}
+
+ServiceManager.prototype.license = function (options, callback) {
+
+}
+
 
 // Pooling
 exports.pool = function(max, options, callback) {
@@ -1459,9 +1735,10 @@ Pool.prototype.destroy = function() {};
  *
  ***************************************/
 
-var Connection = exports.Connection = function (host, port, callback, options, db) {
+var Connection = exports.Connection = function (host, port, callback, options, db, svc) {
     var self = this;
     this.db = db;
+    this.svc = svc
     this._msg = new XdrWriter(32);
     this._blr = new BlrWriter(32);
     this._queue = [];
@@ -2628,6 +2905,106 @@ Connection.prototype.batchSegments = function(blob, buffer, callback){
     msg.addBlr(blr);
     this._queueEvent(callback);
 };
+
+Connection.prototype.svcattach = function (options, callback, svc) {
+    var database = options.database || options.filename;
+    var user = options.user || DEFAULT_USER;
+    var password = options.password || DEFAULT_PASSWORD;
+    var role = options.role;
+    var self = this;
+    var msg = this._msg;
+    var blr = this._blr;
+    msg.pos = 0;
+    blr.pos = 0;
+    
+    blr.addBytes([isc_dpb_version2, isc_dpb_version2]);
+    blr.addString(isc_dpb_lc_ctype, 'UTF8', DEFAULT_ENCODING);
+    blr.addString(isc_dpb_user_name, user, DEFAULT_ENCODING);
+    blr.addString(isc_dpb_password, password, DEFAULT_ENCODING);
+    blr.addByte(isc_dpb_dummy_packet_interval);
+    blr.addByte(4);
+    blr.addBytes([120, 10, 0, 0]); // FROM DOT NET PROVIDER
+    if (role)
+        blr.addString(isc_dpb_sql_role_name, role, DEFAULT_ENCODING);
+
+    msg.addInt(op_service_attach); 
+    msg.addInt(0);
+    msg.addString(DEFAULT_SVC_NAME, DEFAULT_ENCODING); // only local for moment
+    msg.addBlr(this._blr);
+    
+    var self = this;
+    
+    function cb(err, ret) {
+        
+        if (err) {
+            doError(err, callback);
+            return;
+        }
+        
+        self.svchandle = ret.handle;
+        if (callback)
+            callback(undefined, ret);
+    }
+    
+    // For reconnect
+    if (svc) {
+        svc.connection = this;
+        cb.response = svc;
+    } else {
+        cb.response = new ServiceManager(this);
+        cb.response.removeAllListeners('error');
+        cb.response.on('error', noop);
+    }
+    
+    this._queueEvent(cb);        
+}
+
+Connection.prototype.svcstart = function (spbaction, callback) {
+    var msg = this._msg;
+    var blr = this._blr;
+    msg.pos = 0;
+    msg.addInt(op_service_start);
+    msg.addInt(this.svchandle);
+    msg.addInt(0)
+    msg.addBlr(spbaction);
+    this._queueEvent(callback);
+}
+
+Connection.prototype.svcquery = function (spb, spbquery, querysize, callback) {
+    var msg = this._msg;
+    var blr = this._blr;
+    msg.pos = 0;
+    blr.pos = 0;
+    msg.addInt(op_service_info);
+    msg.addInt(this.svchandle);
+    msg.addInt(0)
+    msg.addBlr(spbaction);
+    msg.addBlr(spbquery);
+    msg.addInt(querysize);
+    this._queueEvent(callback);
+}
+
+Connection.prototype.svcdetach = function (callback) {
+    var self = this;
+    
+    if (self._isClosed)
+        return;
+    
+    self._isUsed = false;
+    self._isDetach = true;
+    
+    var msg = self._msg;
+    
+    msg.pos = 0;
+    msg.addInt(op_service_detach);
+    msg.addInt(this.svchandle); // Database Object ID
+    
+    self._queueEvent(function (err, ret) {
+        delete (self.svchandle);
+        if (callback)
+            callback(err, ret);
+    });
+}
 
 function bufferReader(buffer, max, writer, cb, beg, end) {
 

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -43,6 +43,12 @@ BlrWriter.prototype.addWord = function (b) {
     this.pos += 2;
 };
 
+BlrWriter.prototype.addInt32 = function (b) {
+    this.ensure(4);
+    this.buffer.writeUInt32LE(b, this.pos);
+    this.pos += 4;
+};
+
 BlrWriter.prototype.addNumeric = function (c, v) {
 
     if (v < 256){
@@ -85,6 +91,27 @@ BlrWriter.prototype.addString = function (c, s, encoding) {
     this.ensure(len + 1);
     this.buffer.writeUInt8(len, this.pos);
     this.pos++;
+    this.buffer.write(s, this.pos, s.length, encoding);
+    this.pos += len;
+};
+
+BlrWriter.prototype.addBuffer = function (b) {
+    this.addSmall(b.length);
+    this.ensure(b.length);
+    b.copy(this.buffer, this.pos);
+    this.pos += b.length;
+};
+
+BlrWriter.prototype.addString2 = function (c, s, encoding) {
+    this.addByte(c);
+    
+    var len = Buffer.byteLength(s, encoding);
+    if (len > MAX_STRING_SIZE* MAX_STRING_SIZE)
+        throw new Error('blr string is too big');
+    
+    this.ensure(len + 2);
+    this.buffer.writeUInt16LE(len, this.pos);
+    this.pos += 2;
     this.buffer.write(s, this.pos, s.length, encoding);
     this.pos += len;
 };


### PR DESCRIPTION
just a test case, if contributors of node-firebird could comment the
code it could be fine.
if they think that is well coded, i continue to implement the rest of
service manager functionnality

code to use it : 

```javascript
var fb = require('node-firebird');

var _connection = {
	user : 'SYSDBA',
    password : 'masterkey',
    host : '127.0.0.1',
    port : 3050,
    database : '/DB/MYDB.FDB',
	manager : true
}

fb.attach(_connection, function(err, svc) {	
	if (err)
		return;
	svc.backup(
		{
			database:'/DB/MYDB.FDB',
			files: [
					{
					 filename:'/DB/MYDB.FBK', 
					 sizefile:'0'
					}
				   ]
		}, 
		function(err, data) {
			console.log(data);
		});
});
```