### PR TITLE
Add Service Manager functionality

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ var
     net = require('net'),
     os = require('os'),
     Events = require('events'),
+    stream = require('stream'),
     serialize = require('./serialize.js'),
     XdrReader = serialize.XdrReader,
     BlrReader = serialize.BlrReader,
@@ -279,7 +280,10 @@ const
 	isc_action_svc_add_license = 9, /* Adds	a license to the license file */
 	isc_action_svc_remove_license = 10, /* Removes a license from the license file */
 	isc_action_svc_db_stats = 11, /* Retrieves database statistics */
-	isc_action_svc_get_ib_log = 12; /* Retrieves the InterBase log file	from the server	*/
+	isc_action_svc_get_ib_log = 12, /* Retrieves the InterBase log file	from the server	*/  
+    isc_action_svc_get_fb_log = 12, /* Retrieves the Firebird log file	from the server	*/ 
+    isc_action_svc_nbak = 20, /* start nbackup */
+    isc_action_svc_nrest = 21;  /* start nrestore */
 
 const
 	isc_info_svc_svr_db_info = 50, /* Retrieves the number	of attachments and databases */
@@ -300,7 +304,8 @@ const
 	isc_info_svc_get_licensed_users = 65, /* Retrieves the number	of users licensed for accessing	the	server */
 	isc_info_svc_limbo_trans = 66, /* Retrieve	the	limbo transactions */
 	isc_info_svc_running = 67, /* Checks to see if	a service is running on	an attachment */
-	isc_info_svc_get_users = 68; /* Returns the user	information	from isc_action_svc_display_users */
+	isc_info_svc_get_users = 68, /* Returns the user	information	from isc_action_svc_display_users */
+    isc_info_svc_stdin = 78;  
 
 /* Services Properties */	
 const
@@ -313,6 +318,20 @@ const
 	isc_spb_prp_write_mode = 12,
 	isc_spb_prp_access_mode = 13,
 	isc_spb_prp_set_sql_dialect = 14,
+    isc_spb_num_att = 5,
+    isc_spb_num_db = 6,
+    // SHUTDOWN OPTION FOR 2.0
+    isc_spb_prp_force_shutdown = 41,
+    isc_spb_prp_attachments_shutdown = 42,
+    isc_spb_prp_transactions_shutdown = 43,
+    isc_spb_prp_shutdown_mode = 44,
+    isc_spb_prp_online_mode = 45,
+
+    isc_spb_prp_sm_normal = 0,
+    isc_spb_prp_sm_multi = 1,
+    isc_spb_prp_sm_single = 2,
+    isc_spb_prp_sm_full = 3;
+
 
 		// WRITE_MODE_PARAMETERS
 	isc_spb_prp_wm_async = 37,
@@ -330,6 +349,8 @@ const
 	isc_spb_prp_activate = 0x0100,
 	isc_spb_prp_db_online = 0x0200;
 
+    // SHUTDOWN MODE
+
 /* · Backup Service ·*/
 const
 	isc_spb_bkp_file = 5,
@@ -343,7 +364,12 @@ const
     isc_spb_bkp_non_transportable = 0x20,
     isc_spb_bkp_convert = 0x40,
     isc_spb_bkp_expand = 0x80,
-    isc_spb_bkp_no_triggers = 0x8000;
+    isc_spb_bkp_no_triggers = 0x8000,
+    // nbackup
+    isc_spb_nbk_level = 5,
+    isc_spb_nbk_file = 6,
+    isc_spb_nbk_direct = 7,
+    isc_spb_nbk_no_triggers = 0x01;
 
 /*	Restore Service ·*/
 const
@@ -351,9 +377,18 @@ const
 	isc_spb_res_page_size = 10,
 	isc_spb_res_length = 11,
 	isc_spb_res_access_mode = 12,
-
+    isc_spb_res_fix_fss_data = 13,
+    isc_spb_res_fix_fss_metadata = 14,
 	isc_spb_res_am_readonly = isc_spb_prp_am_readonly,
-	isc_spb_res_am_readwrite = isc_spb_prp_am_readwrite;
+	isc_spb_res_am_readwrite = isc_spb_prp_am_readwrite,
+    isc_spb_res_deactivate_idx = 0x0100,
+    isc_spb_res_no_shadow = 0x0200,
+    isc_spb_res_no_validity = 0x0400,
+    isc_spb_res_one_at_a_time = 0x0800,
+    isc_spb_res_replace = 0x1000,
+    isc_spb_res_create = 0x2000,
+    isc_spb_res_use_all_space = 0x4000;
+    
 
 /* · Repair Service ·*/
 const
@@ -374,7 +409,16 @@ const
 	isc_spb_tra_advise = 29,
 	isc_spb_tra_advise_commit = 30,
 	isc_spb_tra_advise_rollback = 31,
-	isc_spb_tra_advise_unknown = 33;
+	isc_spb_tra_advise_unknown = 33,
+    isc_spb_rpr_validate_db = 0x01,
+    isc_spb_rpr_sweep_db = 0x02,
+    isc_spb_rpr_mend_db = 0x04,
+    isc_spb_rpr_list_limbo_trans = 0x08,
+    isc_spb_rpr_check_db = 0x10,
+    isc_spb_rpr_ignore_checksum = 0x20,
+    isc_spb_rpr_kill_shadows = 0x40,
+    isc_spb_rpr_full = 0x80,
+    isc_spb_rpr_icu = 0x0800;
 
 /* · Security Service ·*/
 const
@@ -385,8 +429,25 @@ const
 	isc_spb_sec_groupname = 9,
 	isc_spb_sec_firstname = 10,
 	isc_spb_sec_middlename = 11,
-	isc_spb_sec_lastname = 12;
+	isc_spb_sec_lastname = 12,
+    isc_spb_sec_admin = 13;
 
+/* License Service */
+const
+    isc_spb_lic_key = 5,
+    isc_spb_lic_id = 6,
+    isc_spb_lic_desc = 7;
+
+/* Statistics Service */
+const
+    isc_spb_sts_data_pages = 0x01,
+    isc_spb_sts_db_log = 0x02,
+    isc_spb_sts_hdr_pages = 0x04,
+    isc_spb_sts_idx_pages = 0x08,
+    isc_spb_sts_sys_relations = 0x10,
+    isc_spb_sts_record_versions = 0x20,
+    isc_spb_sts_table = 0x40,
+    isc_spb_sts_nocreation = 0x80;
 
 
 /***********************/
@@ -1563,6 +1624,193 @@ ServiceManager.prototype.__proto__ = Object.create(Events.EventEmitter.prototype
     }
 });
 
+ServiceManager.prototype._createOutputStream = function (optread, buffersize, callback) {
+    var self = this;
+    optread = optread || 'byline';
+    var t = new stream.Readable({ objectMode: optread == 'byline'?true:false }); // chunk by line
+    t.__proto__._read = function () {
+        var selfread = this;
+        var fct = optread == 'byline'?self.readline:self.readeof;
+        fct.call(self, { buffersize: buffersize }, function (err, data) {
+            if (err) {
+                selfread.push(null);
+                return;
+            }
+            if (data.line && data.line.length)
+                selfread.push(data.line, DEFAULT_ENCODING);
+            else
+                selfread.push(null);
+        });
+    }
+    
+    callback(null, t);
+}
+
+
+ServiceManager.prototype._infosmapping = {
+    "50"/*isc_info_svc_svr_db_info*/ : "dbinfo",        
+    "51"/*isc_info_svc_get_license*/ : "licenses",
+    "52"/*isc_info_svc_get_license_mask*/ : "licenseoptions",
+    "53"/*isc_info_svc_get_config*/ : "fbconfig",   
+    "54"/*isc_info_svc_version*/ : "svcversion",
+    "55"/*isc_info_svc_server_version*/ : "fbversion",
+    "56"/*isc_info_svc_implementation*/ : "fbimplementation",
+    "57"/*isc_info_svc_capabilities*/ : "fbcapatibilities",
+    "58"/*isc_info_svc_user_dbpath*/ : "pathsecuritydb",
+    "59"/*isc_info_svc_get_env*/ : "fbenv",
+    "60"/*isc_info_svc_get_env_lock*/ : "fbenvlock",
+    "61"/*isc_info_svc_get_env_msg*/ : "fbenvmsg",
+    "62"/*isc_info_svc_line*/ : "",
+    "63"/*isc_info_svc_to_eof*/ : "",
+    "64"/*isc_info_svc_timeout*/ : "",
+    "65"/*isc_info_svc_get_licensed_users*/ : "",
+    "66"/*isc_info_svc_limbo_trans*/ : "",
+    "67"/*isc_info_svc_running*/ : "",
+    "68"/*isc_info_svc_get_users*/ : "fbusers",
+    "78"/*isc_info_svc_stdin*/ : ""
+};
+
+ServiceManager.prototype._processcapabilities = function (blr, res) {
+    var capArray = [
+        "WAL_SUPPORT", 
+        "MULTI_CLIENT_SUPPORT", 
+        "REMOTE_HOP_SUPPORT", 
+        "NO_SVR_STATS_SUPPORT", 
+        "NO_DB_STATS_SUPPORT", 
+        "LOCAL_ENGINE_SUPPORT", 
+        "NO_FORCED_WRITE_SUPPORT", 
+        "NO_SHUTDOWN_SUPPORT", 
+        "NO_SERVER_SHUTDOWN_SUPPORT",
+        "SERVER_CONFIG_SUPPORT",
+        "QUOTED_FILENAME_SUPPORT"
+    ];
+    var dbcapa = res[this._infosmapping[57]] = [];
+    var caps = blr.readInt32();
+	
+	for (var i = 0; i < capArray.length; ++i)
+		if (caps & (1 << i))
+            dbcapa.push(capArray[i]);
+}
+
+ServiceManager.prototype._processdbinfo = function (blr, res) {
+    var tinfo = blr.readByteCode();
+    var dbinfo = res[this._infosmapping[50]] = {};
+     
+    dbinfo.database = [];
+    for (; tinfo != isc_info_flag_end; tinfo = blr.readByteCode()) {
+        switch (tinfo) {
+            case isc_spb_dbname:
+                dbinfo.database.push(blr.readString());
+                break;
+            case isc_spb_num_att:
+                dbinfo.nbattachment = blr.readInt32();
+                break;
+            case isc_spb_num_db:
+                dbinfo.nbdatabase = blr.readInt32();
+                break;
+        }
+    }
+}
+
+ServiceManager.prototype._processquery = function (buffer, callback) {
+    //console.log(buffer);
+    var br = new BlrReader(buffer);
+    var tinfo = br.readByteCode();
+    var res = {};
+    res.result = 0;
+    for (; tinfo != isc_info_end; tinfo = br.readByteCode()) {
+        switch (tinfo) {
+            case isc_info_svc_server_version:
+            case isc_info_svc_implementation:
+            case isc_info_svc_user_dbpath:
+            case isc_info_svc_get_env:
+            case isc_info_svc_get_env_lock:
+            case isc_info_svc_get_env_msg:
+                res[this._infosmapping[tinfo]] = br.readString();
+                break;
+            case isc_info_svc_version:
+                res[this._infosmapping[tinfo]] = br.readInt32();
+                break;
+            case isc_info_svc_svr_db_info:
+                this._processdbinfo(br, res);
+                break;
+            case isc_info_svc_limbo_trans:
+                // not implemented
+                for (; tinfo != isc_info_flag_end; tinfo = br.readByteCode())
+                break;
+            case isc_info_svc_get_users:
+                br.pos += 2
+                res[this._infosmapping[tinfo]] = [];
+                break;
+            case isc_spb_sec_username:
+                var tuser = res[this._infosmapping[68]];
+                tuser.push({});
+                tuser[tuser.length - 1].username = br.readString();
+                break;
+            case isc_spb_sec_firstname:
+                var tuser = res[this._infosmapping[68]];    
+                var user = tuser[tuser.length-1];
+                user.firstname = br.readString();
+                break;
+            case isc_spb_sec_middlename:
+                var tuser = res[this._infosmapping[68]];
+                var user = tuser[tuser.length-1];
+                user.middlename = br.readString();
+                break;
+            case isc_spb_sec_lastname:
+                var tuser = res[this._infosmapping[68]];
+                var user = tuser[tuser.length-1];
+                user.lastname = br.readString();
+                break;
+            case isc_spb_sec_groupid:
+                var tuser = res[this._infosmapping[68]];
+                var user = tuser[tuser.length-1];
+                user.groupid = br.readInt32();
+                break;
+            case isc_spb_sec_userid:
+                var tuser = res[this._infosmapping[68]];
+                var user = tuser[tuser.length-1];
+                user.userid = br.readInt32();
+                
+                break;
+            case isc_spb_sec_admin:
+                var tuser = res[this._infosmapping[68]];
+                var user = tuser[tuser.length-1];
+                user.admin = br.readInt32();
+                break;
+
+            case isc_info_svc_line:
+                res.line = br.readString();
+                break;
+
+            case isc_info_svc_to_eof:
+                res.line = br.readString();
+                break;
+
+            case isc_info_truncated:
+                res.result = 1; // too much data for the result buffer increase size of it (buffersize parameter))
+                break;
+
+            case isc_info_data_not_ready:
+                res.result = 2;
+                break;
+
+            case isc_info_svc_timeout:
+                res.result = 3;
+                break;            
+
+            case isc_info_svc_stdin:
+                
+                break;
+
+            case isc_info_svc_capabilities:
+                this._processcapabilities(br, res);
+                break; 
+        }
+    }
+    callback(null, res);
+}
+
 ServiceManager.prototype.detach = function(callback, force) {
     var self = this;
     
@@ -1620,59 +1868,674 @@ ServiceManager.prototype.backup = function (options, callback) {
         if (i != bckfiles.length - 1) // not the end, so we need to write the size of this part (gsplit)
             blr.addString2(isc_spb_bkp_length, bckfiles[i].sizefile, DEFAULT_ENCODING);
     }
-    if (factor) {
-        blr.addByte(isc_spb_bkp_factor);
-        blr.addInt32(factor);
-    }
-    var options = 0;
-    if (ignorechecksums) options = options | isc_spb_bkp_ignore_checksums;
-    if (ignorelimbo) options = options | isc_spb_bkp_ignore_limbo;
-    if (metadataonly) options = options | isc_spb_bkp_metadata_only;
-    if (nogarbagecollect) options = options | isc_spb_bkp_no_garbage_collect;
-    if (olddescriptions) options = options | isc_spb_bkp_old_descriptions;
-    if (nontransportable) options = options | isc_spb_bkp_non_transportable;
-    if (convert) options = options | isc_spb_bkp_convert;
-    if (expand) options = options | isc_spb_bkp_expand;
-    if (notriggers) options = options | isc_spb_bkp_no_triggers;
-    if (options) {
-        blr.addByte(isc_spb_options);
-        blr.addInt32(options);
-    }
+    if (factor)
+        blr.addByteInt32(isc_spb_bkp_factor, factor);
+        
+    var opts = 0;
+    if (ignorechecksums) opts = opts | isc_spb_bkp_ignore_checksums;
+    if (ignorelimbo) opts = opts | isc_spb_bkp_ignore_limbo;
+    if (metadataonly) opts = opts | isc_spb_bkp_metadata_only;
+    if (nogarbagecollect) opts = opts | isc_spb_bkp_no_garbage_collect;
+    if (olddescriptions) opts = opts | isc_spb_bkp_old_descriptions;
+    if (nontransportable) opts = opts | isc_spb_bkp_non_transportable;
+    if (convert) opts = opts | isc_spb_bkp_convert;
+    if (expand) opts = opts | isc_spb_bkp_expand;
+    if (notriggers) opts = opts | isc_spb_bkp_no_triggers;
+    if (opts)
+        blr.addByteInt32(isc_spb_options, opts);
     if (verbose)
         blr.addByte(isc_spb_verbose);
+    var self = this;
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid BACKUP Action'), callback); 
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
+}
 
-    this.connection.svcstart(blr, callback);
-
+ServiceManager.prototype.nbackup = function (options, callback) {
+    var dbpath = options.database || this.connection.options.filename || this.connection.options.database;
+    var bckfile = options.backupfile || null;
+    var level = options.level || 0; // nb day for incremental
+    var notriggers = options.notriggers || false;
+    var direct = options.direct || 'on'; // on or off direct write I/O
+    
+    if (dbpath == null || dbpath.length == 0) {
+        doError(new Error('No database specified'), callback);
+        return;
+    }
+    
+    if (bckfile == null || bckfile.length == 0) {
+        doError(new Error('No backup path specified'), callback);
+        return;
+    }
+    
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_nba);
+    blr.addString2(isc_spb_dbname, dbpath, DEFAULT_ENCODING);
+    blr.addString2(isc_spb_dbname, bckfile, DEFAULT_ENCODING);
+    blr.addByteInt32(isc_spb_nbk_level, level);
+    blr.addString2(isc_spb_nbk_direct, direct, DEFAULT_ENCODING);
+    var opts = 0;
+    if (notriggers) opts = opts | isc_spb_nbk_no_triggers;
+    blr.addByteInt32(isc_spb_options, opts);
+    var self = this;
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid NBACKUP Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
 }
 
 ServiceManager.prototype.restore = function(options, callback) {
+    var bckfiles = options.backupfiles || null; // format bckfiles ['file1', 'file2', 'file3']
+    var dbfile = options.database || this.connection.options.filename || this.connection.options.database;; 
+    var verbose = options.verbose || false;
+    var cachebuffers = options.cachebuffers || 2048; // gbak -buffers
+    var pagesize = options.pagesize || 4096; // gbak -page_size
+    var readonly = options.readonly || false; // gbak -mode
+    var deactivateindexes = options.deactivateindexes || false;
+    var	noshadow = options.noshadow || false;
+    var	novalidity = options.novalidity || false;
+    var	individualcommit = options.individualcommit || true; // otherwise no data
+    var	replace = options.replace || false;
+    var	create = options.create || false;
+    var useallspace = options.useallspace || false;
+    var metadataonly = options.metadataonly || false;
+    var fixfssdata = options.fixfssdata || null;
+    var fixfssmetadata = options.fixfssmetadata || null;
 
+    if (bckfiles == null || bckfiles.length == 0) {
+        doError(new Error('No backup file specified'), callback);
+        return;
+    }
+    
+    if (dbfile == null || dbfile.length == 0) {
+        doError(new Error('No database path specified'), callback);
+        return;
+    }
+
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_restore);
+    for (var i = 0; i < bckfiles.length; i++) {
+        blr.addString2(isc_spb_bkp_file, bckfiles[i], DEFAULT_ENCODING);
+    }
+    blr.addString2(isc_spb_dbname, dbfile, DEFAULT_ENCODING);
+    blr.addByte(isc_spb_res_buffers);
+    blr.addInt32(cachebuffers);
+    blr.addByte(isc_spb_res_page_size);
+    blr.addInt32(pagesize);
+    blr.addByte(isc_spb_res_access_mode);
+    if (readonly)
+        blr.addByte(isc_spb_prp_am_readonly);
+    else
+        blr.addByte(isc_spb_prp_am_readwrite);
+    if (fixfssdata) blr.addString2(isc_spb_res_fix_fss_data, fixfssdata, DEFAULT_ENCODING);
+    if (fixfssmetadata) blr.addString2(isc_spb_res_fix_fss_metadata, fixfssmetadata, DEFAULT_ENCODING);
+    var opts = 0;
+    if (deactivateindexes) opts = opts | isc_spb_res_deactivate_idx;
+    if (noshadow) opts = opts | isc_spb_res_no_shadow;
+    if (novalidity) opts = opts | isc_spb_res_no_validity;
+    if (individualcommit) opts = opts | isc_spb_res_one_at_a_time;
+    if (replace) opts = opts | isc_spb_res_replace;
+    if (create) opts = opts | isc_spb_res_create;
+    if (useallspace) opts = opts | isc_spb_res_use_all_space;
+    if (metadataonly) opts = opts | isc_spb_res_fix_fss_metadata;
+    if (opts) 
+        blr.addByteInt32(isc_spb_options, opts);
+    if (verbose)
+        blr.addByte(isc_spb_verbose);
+    var self = this;
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid RESTORE Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
 }
 
-ServiceManager.prototype.gfix = function (options, callback) {
-
+ServiceManager.prototype.nrestore = function (options, callback) {
+    var bckfiles = options.backupfiles || null; // format bckfiles ['file1', 'file2', 'file3']
+    var dbpath = options.database || this.connection.options.filename || this.connection.options.database;;
+    
+    if (bckfiles == null || bckfiles.length == 0) {
+        doError(new Error('No backup file specified'), callback);
+        return;
+    }
+    
+    if (dbpath == null || dbfile.length == 0) {
+        doError(new Error('No database path specified'), callback);
+        return;
+    }
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_nrest);
+    for (var i = 0; i < bckfiles.length; i++) {
+        blr.addString2(isc_spb_nbk_file, bckfiles[i], DEFAULT_ENCODING);
+    }
+    blr.addString2(isc_spb_dbname, dbpath, DEFAULT_ENCODING);
+    var self = this;
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid NRESTORE Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
 }
 
-ServiceManager.prototype.repair = function (options, callback) {
+// only one at time don't use this function directly
+ServiceManager.prototype._fixpropertie = function (options, callback) {
+    var dbpath = options.database || this.connection.options.filename || this.connection.options.database;
+    var dialect = options.dialect || null;
+    var sweep = options.sweepinterval || null;
+    var pagebuffers = options.nbpagebuffers || null;
+    var online = options.bringonline || false;
+    var shutdown = options.shutdown || null; // 0 Forced, 1 deny transaction, 2 deny attachment
+    var shutdowndelay = options.shutdowndelay || 0;
+    var shutdownmode = options.shutdownmode || null; // 0 normal 1 multi 2 single 3 full
+    var shadow = options.activateshadow || false;
+    var forcewrite = options.forcewrite!=null?options.forcewrite:null;
+    var reservespace = options.reservespace!=null?options.reservespace:null;
+    var accessmode = options.accessmode!=null?options.accesmode:null; // 0 readonly 1 readwrite
 
+    if (dbpath == null || dbpath.length == 0) {
+        doError(new Error('No database specified'), callback);
+        return;
+    }
+
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_properties);
+    blr.addString2(isc_spb_dbname, dbpath, DEFAULT_ENCODING);
+    if (dialect) blr.addByteInt32(isc_spb_prp_set_sql_dialect, dialect);
+    if (sweep) blr.addByteInt32(isc_spb_prp_sweep_interval, sweep);
+    if (pagebuffers) blr.addByteInt32(isc_spb_prp_page_buffers, pagebuffers);
+    if (shutdown) {
+        switch (shutdown) { 
+            case 0:
+                blr.addByteInt32(isc_spb_prp_shutdown_db, shutdowndelay);
+                break;
+            case 1:
+                blr.addByteInt32(isc_spb_prp_deny_new_transactions, shutdowndelay);
+                break;
+            case 2:
+                blr.addByteInt32(isc_spb_prp_deny_new_attachments, shutdowndelay);                
+                break;
+        }
+        if (shutdownmode != null) {
+            switch (shutdownmode) {
+                case 0:
+                    blr.addByteInt32(isc_spb_prp_shutdown_mode, isc_spb_prp_sm_normal);
+                    break;
+                case 1:
+                    blr.addByteInt32(isc_spb_prp_shutdown_mode, isc_spb_prp_sm_multi);
+                    break;
+                case 2:
+                    blr.addByteInt32(isc_spb_prp_shutdown_mode, isc_spb_prp_sm_single);
+                    break;
+                case 3:
+                    blr.addByteInt32(isc_spb_prp_shutdown_mode, isc_spb_prp_sm_full);
+                    break;
+            }
+        }
+    }
+    if (forcewrite) blr.addBytes([isc_spb_prp_write_mode, isc_spb_prp_wm_sync]);
+    if (forcewrite != null && !forcewrite) blr.addBytes([isc_spb_prp_write_mode, isc_spb_prp_wm_async]);
+    if (accessmode) blr.addBytes([isc_spb_prp_access_mode, isc_spb_prp_am_readwrite]);
+    if (accessmode != null && !accessmode) blr.addBytes([isc_spb_prp_access_mode, isc_spb_prp_am_readonly]);
+    if (reservespace) blr.addBytes([isc_spb_prp_reserve_space, sc_spb_prp_res]);
+    if (reservespace != null && !reservespace) blr.addBytes([isc_spb_prp_reserve_space, isc_spb_prp_res_use_full]);
+    var opts = 0;
+    if (shadow) opts = opts | sc_spb_prp_activate;
+    if (online) opts = opts | isc_spb_prp_db_online;
+    if (opts)
+        blr.addByteInt32(isc_spb_options, opts);
+    var self = this;
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid PROPERTIE Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });    
 }
 
-ServiceManager.prototype.stats = function (options, callback) {
-
+ServiceManager.prototype.setDialect = function (db, dialect, callback) {
+    this._fixpropertie({ database: db, dialect: dialect }, callaback);
 }
 
-ServiceManager.prototype.log = function (options, callback) {
-
+ServiceManager.prototype.setSweepinterval = function (db, sweepinterval, callback) {
+    this._fixpropertie({ database: db, sweepinterval: sweepinterval }, callback);
 }
 
-ServiceManager.prototype.gsec = function (options, callback) {
-
+ServiceManager.prototype.setCachebuffer = function (db, nbpages, callback) {
+    this._fixpropertie({ database: db, nbpagebuffers: nbpages }, callback);
 }
 
-ServiceManager.prototype.license = function (options, callback) {
-
+ServiceManager.prototype.BringOnline = function (db, callback) {
+    this._fixpropertie({ database: db, bringonline: true }, callback);
 }
 
+ServiceManager.prototype.Shutdown = function (db, kind, delay, mode, callback) {
+    // mode parameter is for server version >= 2.0
+    this._fixpropertie({ database: db, shutdown: kind, shutdowndelay: delay, shutdownmode: mode }, callback);
+}
+
+ServiceManager.prototype.setShadow = function (db, val, callback) {
+    this._fixpropertie({ database: db, activateshadow : val }, callback);
+}
+
+ServiceManager.prototype.setForcewrite = function (db, val, callback) {
+    this._fixpropertie({ database: db, forcewrite : val }, callback);
+}
+
+ServiceManager.prototype.setReservespace = function (db, val, callback) {
+    this._fixpropertie({ database: db, reservespace : val }, callback);
+}
+
+ServiceManager.prototype.setReadonlyMode = function (db, callback) {
+    this._fixpropertie({ database: db, accessmode : 0 }, callback);
+}
+
+ServiceManager.prototype.setReadwriteMode = function (db, callback) {
+    this._fixpropertie({ database: db, accessmode : 1 }, callback);
+}
+
+ServiceManager.prototype.validate = function (options, callback) {
+    var dbpath = options.database || this.connection.options.filename || this.connection.options.database;
+    var checkdb = options.checkdb || false;
+    var ignorechecksums = options.ignorechecksums || false;
+    var killshadows = options.killshadows || false;
+    var mend = options.mends || false;
+    var validate = options.validate || false;
+    var full = options.full || false;
+    var sweep = options.sweep || false;
+    var listlimbo = options.listlimbo || false;
+    var icu = options.icu || false;
+
+    if (dbpath == null || dbpath.length == 0) {
+        doError(new Error('No database specified'), callback);
+        return;
+    }
+    
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_repair);
+    blr.addString2(isc_spb_dbname, dbpath, DEFAULT_ENCODING);
+    var opts = 0;
+    if (checkdb) opts = opts | isc_spb_rpr_check_db;
+    if (ignorechecksums) opts = opts | isc_spb_rpr_ignore_checksum;
+    if (rpr_kill_shadows) opts = opts | isc_spb_rpr_kill_shadows;
+    if (mend) opts = opts | isc_spb_rpr_mend_db;
+    if (validate) opts = opts | isc_spb_rpr_validate_db;
+    if (full) opts = opts | isc_spb_rpr_full;
+    if (sweep) opts = opts | isc_spb_rpr_sweep_db;
+    if (listlimbo) opts = opts | isc_spb_rpr_list_limbo_trans;
+    if (icu) opts = opts | isc_spb_rpr_icu;
+    blr.addByteInt32(isc_spb_options, opts);
+    var self = this;
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid VALIDATE Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    }); 
+}
+
+ServiceManager.prototype.commit = function(db, transactid, callback) {
+    var dbpath = options.database || this.connection.options.filename || this.connection.options.database;
+    if (dbpath == null || dbpath.length == 0) {
+        doError(new Error('No database specified'), callback);
+        return;
+    }
+    
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_repair);
+    blr.addString2(isc_spb_dbname, dbpath, DEFAULT_ENCODING);
+    blr.addByteInt32(isc_spb_rpr_commit_trans, transactid);
+    var self = this;
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid COMMIT Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    }); 
+}
+
+ServiceManager.prototype.rollback = function (db, transactid, callback) {
+    var dbpath = options.database || this.connection.options.filename || this.connection.options.database;
+    if (dbpath == null || dbpath.length == 0) {
+        doError(new Error('No database specified'), callback);
+        return;
+    }
+    
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_repair);
+    blr.addString2(isc_spb_dbname, dbpath, DEFAULT_ENCODING);
+    blr.addByteInt32(isc_spb_rpr_rollback_trans, transactid);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid ROLLBACK Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    }); 
+}
+
+ServiceManager.prototype.recover = function (db, transactid, callback) {
+    var dbpath = options.database || this.connection.options.filename || this.connection.options.database;
+    if (dbpath == null || dbpath.length == 0) {
+        doError(new Error('No database specified'), callback);
+        return;
+    }
+    
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_repair);
+    blr.addString2(isc_spb_dbname, dbpath, DEFAULT_ENCODING);
+    blr.addByteInt32(isc_spb_rpr_recover_two_phase, transactid);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid RECOVER Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    }); 
+}
+
+ServiceManager.prototype.getStats = function (options, callback) {
+    var dbpath = options.database || this.connection.options.filename || this.connection.options.database;
+    var record = options.record || false;
+    var nocreation = options.nocreation || false;
+    var tables = options.tables || false;
+    var pages = options.pages || false;
+    var header = options.header || false;
+    var indexes = options.indexes || false;
+    var tablesystem = options.tablesystem || false;
+    var encryption = options.encryption || false;
+    var objects = options.objects || null; // space-separated list of object index,table,systemtable
+    if (dbpath == null || dbpath.length == 0) {
+        doError(new Error('No database specified'), callback);
+        return;
+    }
+    
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_db_stats);
+    blr.addString2(isc_spb_dbname, dbpath, DEFAULT_ENCODING);
+    var opts = 0;
+    if (record) opts = opts | isc_spb_sts_record_versions;
+    if (nocreation) opts = opts | isc_spb_sts_nocreation;
+    if (tables) opts = opts | isc_spb_sts_table;
+    if (pages) opts = opts | isc_spb_sts_data_pages;
+    if (header) opts = opts | isc_spb_sts_hdr_pages;
+    if (indexes) opts = opts | isc_spb_sts_idx_pages;
+    if (tablesystem) opts = opts | isc_spb_sts_sys_relations;
+    if (encryption) opts = opts | isc_spb_sts_encryption;
+    if (opts)
+        blr.addByteInt32(isc_spb_options, opts);
+    if (objects) blr.addString2(isc_spb_command_line, objects, DEFAULT_ENCODING);
+    var self = this;
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid STATS Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
+    
+}
+
+ServiceManager.prototype.getLog = function (options, callback) {
+    var self = this;
+    var blr = this.connection._blr;
+    var optread = options.optread || 'byline';
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_get_fb_log);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid LOG Action'), callback);
+            return;
+        }
+        self._createOutputStream(optread, options.buffersize, callback);
+    });
+}
+
+ServiceManager.prototype.getUsers = function (username, callback) {
+    var self = this;
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_display_user);
+    if (username) blr.addString2(isc_spb_sec_username, username, DEFAULT_ENCODING);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid DispalyUser Action'), callback);
+            return;
+        }
+        self.readusers({}, callback);
+    });
+}
+
+ServiceManager.prototype.addUser = function (username, password, options, callback) {
+    var rolename = options.rolename || null;
+    var groupname = options.groupname || null;
+    var firsname = options.firstname || null;
+    var middlename = options.middlename || null;
+    var lastname = options.lastname || null;
+    var userid = options.userid || null;
+    var groupid = options.groupid || null;
+    var admin = options.admin || null;
+
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_add_user);
+    blr.addString2(isc_spb_sec_username, username, DEFAULT_ENCODING);
+    blr.addString2(isc_spb_sec_password, password, DEFAULT_ENCODING);
+    if (rolename) blr.addString2(isc_dpb_sql_role_name, rolename, DEFAULT_ENCODING);
+    if (groupname) blr.addString2(isc_spb_sec_groupname, groupname, DEFAULT_ENCODING);
+    if (firsname) blr.addString2(isc_spb_sec_firstname, firsname, DEFAULT_ENCODING);
+    if (middlename) blr.addString2(isc_spb_sec_middlename, middlename, DEFAULT_ENCODING);
+    if (lastname) blr.addString2(isc_spb_sec_lastname, lastname, DEFAULT_ENCODING);
+    if (userid != null) blr.addByteInt32(isc_spb_sec_userid, userid);
+    if (groupid != null) blr.addByteInt32(isc_spb_sec_groupid, groupid);
+    if (admin != null) blr.addByteInt32(isc_spb_sec_admin, admin);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid ADDUSER Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
+}
+
+ServiceManager.prototype.editUser = function (username, options, callback) {
+    var rolename = options.rolename || null;
+    var groupname = options.groupname || null;
+    var firsname = options.firstname || null;
+    var middlename = options.middlename || null;
+    var lastname = options.lastname || null;
+    var userid = options.userid || null;
+    var groupid = options.groupid || null;
+    var admin = options.admin || null;
+
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_modify_user);
+    blr.addString2(isc_spb_sec_username, username, DEFAULT_ENCODING);
+    blr.addString2(isc_spb_sec_password, password, DEFAULT_ENCODING);
+    if (rolename) blr.addString2(isc_dpb_sql_role_name, rolename, DEFAULT_ENCODING);
+    if (groupname) blr.addString2(isc_spb_sec_groupname, groupname, DEFAULT_ENCODING);
+    if (firsname) blr.addString2(isc_spb_sec_firstname, firsname, DEFAULT_ENCODING);
+    if (middlename) blr.addString2(isc_spb_sec_middlename, middlename, DEFAULT_ENCODING);
+    if (lastname) blr.addString2(isc_spb_sec_lastname, lastname, DEFAULT_ENCODING);
+    if (userid != null) blr.addByteInt32(isc_spb_sec_userid, userid);
+    if (groupid != null) blr.addByteInt32(isc_spb_sec_groupid, groupid);
+    if (admin != null) blr.addByteInt32(isc_spb_sec_admin, admin);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid EDITUSER Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
+}
+
+ServiceManager.prototype.removeUser = function (username, rolename, callback) {
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_delete_user);
+    blr.addString2(isc_spb_sec_username, username, DEFAULT_ENCODING);
+    if (rolename) blr.addString2(isc_dpb_sql_role_name, rolename, DEFAULT_ENCODING);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid REMOVEUSER Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
+}
+
+ServiceManager.prototype.addLicense = function (db, key, id, desc,callback) {
+    // not sure for firebird
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_add_license);
+    blr.addByteInt32(isc_spb_lic_key, key);
+    blr.addByteInt32(isc_spb_lic_id, id);
+    blr.addByteInt32(isc_spb_lic_desc, desc);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid ADDLICENSE Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
+}
+
+ServiceManager.prototype.removeLicense = function (db, key, id, callback) {
+    // not sure for firebird
+    var blr = this.connection._blr;
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_remove_license);
+    blr.addByteInt32(isc_spb_lic_key, key);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid REMOVELICENSE Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
+}
+
+ServiceManager.prototype.getFbserverInfos = function (infos, options, callback) {
+    var buffersize = options.buffersize || 2048;
+    var timeout = options.timeout || 1;
+    var opts = {
+        "dbinfo" : isc_info_svc_svr_db_info,
+        "fbconfig" : isc_info_svc_get_config,
+        "svcversion" : isc_info_svc_version,
+        "fbversion" : isc_info_svc_server_version,
+        "fbimplementation" : isc_info_svc_implementation,
+        "fbcapatibilities" : isc_info_svc_capabilities,
+        "pathsecuritydb" : isc_info_svc_user_dbpath,
+        "fbenv" : isc_info_svc_get_env,
+        "fbenvlock" : isc_info_svc_get_env_lock,
+        "fbenvmsg" : isc_info_svc_get_env_msg
+    };
+    // if infos is empty all options are asked to the service
+
+    var tops = [];
+    for (popts in opts)
+        if (infos[popts] || infos.length == 0)
+            tops.push(opts[popts]);
+    
+    
+    var self = this;
+    this.connection.svcquery(tops, buffersize, timeout, function (err, data) {
+        if (err || !data.buffer) {
+            doError(new Error('Bad query return'), callback);
+            return;
+        }
+        self._processquery(data.buffer, callback);
+    });
+}
+
+ServiceManager.prototype.readline = function (options, callback) {
+    var buffersize = options.buffersize || 2048;
+    var timeout = options.timeout || 60;
+    var self = this;
+    this.connection.svcquery([isc_info_svc_line], buffersize, timeout, function (err, data) {
+        if (err || !data.buffer) {
+            doError(new Error('Bad query return'), callback);
+            return;
+        }
+        self._processquery(data.buffer, callback);
+    });
+}
+
+ServiceManager.prototype.readeof = function (options, callback) {
+    var buffersize = options.buffersize || (8 * 1024);
+    var timeout = options.timeout || 60;
+    var self = this;
+    this.connection.svcquery([isc_info_svc_to_eof], buffersize, timeout, function (err, data) {
+        if (err || !data.buffer) {
+            doError(new Error('Bad query return'), callback);
+            return;
+        }
+        self._processquery(data.buffer, callback);
+    });
+}
+
+ServiceManager.prototype.isRunning = function (options, callback) {
+    var buffersize = options.buffersize || 2048;
+    var timeout = options.timeout || 60;
+    var self = this;
+    this.connection.svcquery([isc_info_svc_running], buffersize, timeout, function (err, data) {
+        if (err || !data.buffer) {
+            doError(new Error('Bad query return'), callback);
+            return;
+        }
+        self._processquery(data.buffer, callback);
+    });
+}
+
+ServiceManager.prototype.readusers = function (options, callback) {
+    var buffersize = options.buffersize || 2048;
+    var timeout = options.timeout || 60;
+    var self = this;
+    this.connection.svcquery([isc_info_svc_get_users], buffersize, timeout, function (err, data) {
+        if (err || !data.buffer) {
+            doError(new Error('Bad query return'), callback);
+            return;
+        }
+        self._processquery(data.buffer, callback);
+    });
+}
+
+ServiceManager.prototype.readlimbo = function (options, callback) {
+    var buffersize = options.buffersize || 2048;
+    var timeout = options.timeout || 60;
+    var self = this;
+    this.connection.svcquery([isc_info_svc_limbo_trans], buffersize, timeout, function (err, data) {
+        if (err || !data.buffer) {
+            doError(new Error('Bad query return'), callback);
+            return;
+        }
+        self._processquery(data.buffer, callback);
+    });
+}
 
 // Pooling
 exports.pool = function(max, options, callback) {
@@ -1825,7 +2688,6 @@ exports.Connection.prototype._bind_events = function(host, port, callback) {
     });
 
     self._socket.on('data', function(data) {
-
         var obj, cb, pos, xdr, buf;
 
         if (!self._xdr) {
@@ -2970,17 +3832,21 @@ Connection.prototype.svcstart = function (spbaction, callback) {
     this._queueEvent(callback);
 }
 
-Connection.prototype.svcquery = function (spb, spbquery, querysize, callback) {
+Connection.prototype.svcquery = function (spbquery, resultbuffersize, timeout,callback) {
     var msg = this._msg;
     var blr = this._blr;
     msg.pos = 0;
     blr.pos = 0;
+    blr.addByte(2);
+    //blr.addByteInt32(isc_info_svc_timeout, timeout);
     msg.addInt(op_service_info);
     msg.addInt(this.svchandle);
     msg.addInt(0)
-    msg.addBlr(spbaction);
-    msg.addBlr(spbquery);
-    msg.addInt(querysize);
+    msg.addBlr(blr);
+    blr.pos = 0
+    blr.addBytes(spbquery);
+    msg.addBlr(blr);
+    msg.addInt(resultbuffersize);
     this._queueEvent(callback);
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,6 +111,9 @@ if (String.prototype.parseDate === undefined) {
 function noop() {}
 
 const
+    MAX_BUFFER_SIZE = 8192;
+
+const
     op_void                   = 0,  // Packet has been voided
     op_connect                = 1,  // Connect to remote server
     op_exit                   = 2,  // Remote end has exitted
@@ -281,9 +284,14 @@ const
 	isc_action_svc_remove_license = 10, /* Removes a license from the license file */
 	isc_action_svc_db_stats = 11, /* Retrieves database statistics */
 	isc_action_svc_get_ib_log = 12, /* Retrieves the InterBase log file	from the server	*/  
-    isc_action_svc_get_fb_log = 12, /* Retrieves the Firebird log file	from the server	*/ 
+    isc_action_svc_get_fb_log = isc_action_svc_get_ib_log, /* Retrieves the Firebird log file	from the server	*/ 
     isc_action_svc_nbak = 20, /* start nbackup */
-    isc_action_svc_nrest = 21;  /* start nrestore */
+    isc_action_svc_nrest = 21,  /* start nrestore */
+    isc_action_svc_trace_start = 22,
+    isc_action_svc_trace_stop = 23,
+    isc_action_svc_trace_suspend = 24,
+    isc_action_svc_trace_resume = 25,
+    isc_action_svc_trace_list = 26;
 
 const
 	isc_info_svc_svr_db_info = 50, /* Retrieves the number	of attachments and databases */
@@ -448,6 +456,12 @@ const
     isc_spb_sts_record_versions = 0x20,
     isc_spb_sts_table = 0x40,
     isc_spb_sts_nocreation = 0x80;
+
+/* Trace Service */
+const
+    isc_spb_trc_id = 1,
+    isc_spb_trc_name = 2,
+    isc_spb_trc_cfg = 3;
 
 
 /***********************/
@@ -1888,7 +1902,7 @@ ServiceManager.prototype.backup = function (options, callback) {
     var self = this;
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid BACKUP Action'), callback); 
+            doError(new Error(err), callback); 
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -1925,7 +1939,7 @@ ServiceManager.prototype.nbackup = function (options, callback) {
     var self = this;
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid NBACKUP Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -1994,7 +2008,7 @@ ServiceManager.prototype.restore = function(options, callback) {
     var self = this;
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid RESTORE Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -2024,7 +2038,7 @@ ServiceManager.prototype.nrestore = function (options, callback) {
     var self = this;
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid NRESTORE Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -2101,7 +2115,7 @@ ServiceManager.prototype._fixpropertie = function (options, callback) {
     var self = this;
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid PROPERTIE Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -2184,7 +2198,7 @@ ServiceManager.prototype.validate = function (options, callback) {
     var self = this;
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid VALIDATE Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -2206,7 +2220,7 @@ ServiceManager.prototype.commit = function(db, transactid, callback) {
     var self = this;
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid COMMIT Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -2227,7 +2241,7 @@ ServiceManager.prototype.rollback = function (db, transactid, callback) {
     blr.addByteInt32(isc_spb_rpr_rollback_trans, transactid);
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid ROLLBACK Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -2248,7 +2262,7 @@ ServiceManager.prototype.recover = function (db, transactid, callback) {
     blr.addByteInt32(isc_spb_rpr_recover_two_phase, transactid);
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid RECOVER Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -2290,7 +2304,7 @@ ServiceManager.prototype.getStats = function (options, callback) {
     var self = this;
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid STATS Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -2306,7 +2320,7 @@ ServiceManager.prototype.getLog = function (options, callback) {
     blr.addByte(isc_action_svc_get_fb_log);
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid LOG Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(optread, options.buffersize, callback);
@@ -2321,7 +2335,7 @@ ServiceManager.prototype.getUsers = function (username, callback) {
     if (username) blr.addString2(isc_spb_sec_username, username, DEFAULT_ENCODING);
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid DispalyUser Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self.readusers({}, callback);
@@ -2353,7 +2367,7 @@ ServiceManager.prototype.addUser = function (username, password, options, callba
     if (admin != null) blr.addByteInt32(isc_spb_sec_admin, admin);
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid ADDUSER Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -2385,7 +2399,7 @@ ServiceManager.prototype.editUser = function (username, options, callback) {
     if (admin != null) blr.addByteInt32(isc_spb_sec_admin, admin);
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid EDITUSER Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -2400,7 +2414,7 @@ ServiceManager.prototype.removeUser = function (username, rolename, callback) {
     if (rolename) blr.addString2(isc_dpb_sql_role_name, rolename, DEFAULT_ENCODING);
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid REMOVEUSER Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -2417,7 +2431,7 @@ ServiceManager.prototype.addLicense = function (db, key, id, desc,callback) {
     blr.addByteInt32(isc_spb_lic_desc, desc);
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid ADDLICENSE Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -2432,7 +2446,7 @@ ServiceManager.prototype.removeLicense = function (db, key, id, callback) {
     blr.addByteInt32(isc_spb_lic_key, key);
     this.connection.svcstart(blr, function (err, data) {
         if (err) {
-            doError(new Error('Invalid REMOVELICENSE Action'), callback);
+            doError(new Error(err), callback);
             return;
         }
         self._createOutputStream(options.optread, options.buffersize, callback);
@@ -2465,10 +2479,135 @@ ServiceManager.prototype.getFbserverInfos = function (infos, options, callback) 
     var self = this;
     this.connection.svcquery(tops, buffersize, timeout, function (err, data) {
         if (err || !data.buffer) {
-            doError(new Error('Bad query return'), callback);
+            doError(new Error(err||'Bad query return'), callback);
             return;
         }
         self._processquery(data.buffer, callback);
+    });
+}
+
+ServiceManager.prototype.startTrace = function (options, callback) {
+    var self = this;
+    var blr = this.connection._blr;
+    var configfile = options.configfile || '';
+    var tracename = options.tracename || '';
+    
+    if (configfile.length == 0) {
+        doError(new Error('No config filename specified'), callback);
+        return;
+    }
+    if (tracename.length == 0) {
+        doError(new Error('No tracename specified'), callback);
+        return;
+    }
+
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_trace_start);
+    blr.addString2(isc_spb_trc_cfg, configfile, DEFAULT_ENCODING);
+    blr.addString2(isc_spb_trc_name, tracename, DEFAULT_ENCODING);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error(err), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
+}
+
+ServiceManager.prototype.suspendTrace = function (options, callback) {
+    var self = this;
+    var blr = this.connection._blr;
+    var traceid = options.traceid || null;
+    var tracename = options.tracename || '';
+    
+    if (traceid == null) {
+        doError(new Error('No traceid specified'), callback);
+        return;
+    }
+    if (tracename.length == 0) {
+        doError(new Error('No tracename specified'), callback);
+        return;
+    }
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_trace_suspend);
+    blr.addString2(isc_spb_trc_name, tracename, DEFAULT_ENCODING);
+    blr.addByteInt32(isc_spb_trc_id, traceid);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error(err), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
+}
+
+ServiceManager.prototype.resumeTrace = function (options, callback) {
+    var self = this;
+    var blr = this.connection._blr;
+    var traceid = options.traceid || null;
+    var tracename = options.tracename || '';
+    
+    if (traceid == null) {
+        doError(new Error('No traceid specified'), callback);
+        return;
+    }   
+    if (tracename.length == 0) {
+        doError(new Error('No tracename specified'), callback);
+        return;
+    }
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_trace_resume);
+    blr.addString2(isc_spb_trc_name, tracename, DEFAULT_ENCODING);
+    blr.addByteInt32(isc_spb_trc_id, traceid);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error('Invalid RESUMETRACE Action'), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
+}
+
+ServiceManager.prototype.stopTrace = function (options, callback) {
+    var self = this;
+    var blr = this.connection._blr;
+    var traceid = options.traceid || null;
+    var tracename = options.tracename || '';
+    
+    if (traceid == null) {
+        doError(new Error('No traceid specified'), callback);
+        return;
+    }
+    
+    if (tracename.length == 0) {
+        doError(new Error('No tracename specified'), callback);
+        return;
+    }
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_trace_stop);
+    blr.addString2(isc_spb_trc_name, tracename, DEFAULT_ENCODING);
+    blr.addByteInt32(isc_spb_trc_id, traceid);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error(err), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
+    });
+}
+
+ServiceManager.prototype.getTraceList = function (options, callback) {
+    var self = this;
+    var blr = this.connection._blr;
+    var optread = options.optread || 'byline';
+    blr.pos = 0;
+    blr.addByte(isc_action_svc_trace_list);
+    this.connection.svcstart(blr, function (err, data) {
+        if (err) {
+            doError(new Error(err), callback);
+            return;
+        }
+        self._createOutputStream(options.optread, options.buffersize, callback);
     });
 }
 
@@ -2478,7 +2617,7 @@ ServiceManager.prototype.readline = function (options, callback) {
     var self = this;
     this.connection.svcquery([isc_info_svc_line], buffersize, timeout, function (err, data) {
         if (err || !data.buffer) {
-            doError(new Error('Bad query return'), callback);
+            doError(new Error(err||'Bad query return'), callback);
             return;
         }
         self._processquery(data.buffer, callback);
@@ -2491,7 +2630,7 @@ ServiceManager.prototype.readeof = function (options, callback) {
     var self = this;
     this.connection.svcquery([isc_info_svc_to_eof], buffersize, timeout, function (err, data) {
         if (err || !data.buffer) {
-            doError(new Error('Bad query return'), callback);
+            doError(new Error(err||'Bad query return'), callback);
             return;
         }
         self._processquery(data.buffer, callback);
@@ -2504,7 +2643,7 @@ ServiceManager.prototype.isRunning = function (options, callback) {
     var self = this;
     this.connection.svcquery([isc_info_svc_running], buffersize, timeout, function (err, data) {
         if (err || !data.buffer) {
-            doError(new Error('Bad query return'), callback);
+            doError(new Error(err||'Bad query return'), callback);
             return;
         }
         self._processquery(data.buffer, callback);
@@ -2517,7 +2656,7 @@ ServiceManager.prototype.readusers = function (options, callback) {
     var self = this;
     this.connection.svcquery([isc_info_svc_get_users], buffersize, timeout, function (err, data) {
         if (err || !data.buffer) {
-            doError(new Error('Bad query return'), callback);
+            doError(new Error(err||'Bad query return'), callback);
             return;
         }
         self._processquery(data.buffer, callback);
@@ -2530,7 +2669,7 @@ ServiceManager.prototype.readlimbo = function (options, callback) {
     var self = this;
     this.connection.svcquery([isc_info_svc_limbo_trans], buffersize, timeout, function (err, data) {
         if (err || !data.buffer) {
-            doError(new Error('Bad query return'), callback);
+            doError(new Error(err||'Bad query return'), callback);
             return;
         }
         self._processquery(data.buffer, callback);
@@ -3833,11 +3972,16 @@ Connection.prototype.svcstart = function (spbaction, callback) {
 }
 
 Connection.prototype.svcquery = function (spbquery, resultbuffersize, timeout,callback) {
+    if (resultbuffersize > MAX_BUFFER_SIZE) {
+        doError(new Error('Buffer is too big'), callback);
+        return;
+    }
+    
     var msg = this._msg;
     var blr = this._blr;
     msg.pos = 0;
     blr.pos = 0;
-    blr.addByte(2);
+    blr.addByte(isc_spb_current_version);
     //blr.addByteInt32(isc_info_svc_timeout, timeout);
     msg.addInt(op_service_info);
     msg.addInt(this.svchandle);

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -49,6 +49,13 @@ BlrWriter.prototype.addInt32 = function (b) {
     this.pos += 4;
 };
 
+BlrWriter.prototype.addByteInt32 = function (c, b) {
+    this.addByte(c);
+    this.ensure(4);
+    this.buffer.writeUInt32LE(b, this.pos);
+    this.pos += 4;
+};
+
 BlrWriter.prototype.addNumeric = function (c, v) {
 
     if (v < 256){
@@ -137,6 +144,12 @@ var BlrReader = exports.BlrReader = function(buffer) {
 BlrReader.prototype.readByteCode = function(){
     return this.buffer.readUInt8(this.pos++);
 };
+
+BlrReader.prototype.readInt32 = function () {
+    var value = this.buffer.readUInt32LE(this.pos);
+    this.pos += 4;
+    return value;
+}
 
 BlrReader.prototype.readInt = function(){
     var len = this.buffer.readUInt16LE(this.pos);


### PR DESCRIPTION
List of function implemeted :

backup=> return stream
nbackup=> return stream
restore=> return stream
nrestore => return stream
fixpropertie  => return stream
serverinfo => return object
database validation => return stream
comit transact => return stream
rollback transact => return stream
recover transact => return stream
license ??? => return stream
database stats => return stream
users infos => return object
user actions // add modify remove => return stream
get fb file log => return stream
  
this is an exemple to use with stream and object

```javascript
fb.attach(_connection, function(err, svc) {	
	if (err)
		return;
	// all function that return a stream take two optional parameter
	// optread => byline or buffer	byline use isc_info_svc_line and buffer use isc_info_svc_to_eof
	// buffersize => is the buffer for service manager it can't exceed 8ko (i'm not sure)
		
	svc.getLog({optread:'buffer', buffersize:2048}, function (err, data) {
            // data is a readablestream that contain the firebird.log file
            console.log(err);
            data.on('data', function (data) {
                console.log(data.toString());
            });
			data.on('end', function() {
				console.log('finish');
			});
        });
		
	// an other exemple to use function that return object
	svc.getFbserverInfos(
            {
            "dbinfo" : true,
            "fbconfig" : true,
            "svcversion" : true,
            "fbversion" : true,
            "fbimplementation" : true,
            "fbcapatibilities" : true,
            "pathsecuritydb" : true,
            "fbenv" : true,
            "fbenvlock" : true,
            "fbenvmsg" : true
        }, {}, function (err, data) {
            console.log(err);
            console.log(data);
        });	
});
```

It stays a lot of test to do ;) but globally it works well.
the main function to stay to implement are :

1) trace
2) limbo
