### PR TITLE
Don't try to read from an empty buffer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3786,10 +3786,12 @@ function fetch_blob_async(statement, id, name) {
                             return;
                         }
 
-                        var blr = new BlrReader(ret.buffer);
-                        var data = blr.readSegment();
+                        if (ret.buffer) {
+                            var blr = new BlrReader(ret.buffer);
+                            var data = blr.readSegment();
 
-                        e.emit('data', data);
+                            e.emit('data', data);
+                        }
 
                         if (ret.handle !== 2) {
                             read();


### PR DESCRIPTION
In some cases getSegment can get an empty (undefined) buffer which
result to InternalError: "Cannot call method 'readUInt16LE' of
undefined".