### PR TITLE
Fix date parameter overflow

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1166,6 +1166,13 @@ SQLParamDate.prototype.encode = function(data) {
         var time = value % TimeCoeff;
         var date = (value - time) / TimeCoeff + DateOffset;
         time *= 10;
+
+        // check overflow
+        if (time < 0) {
+            date--;
+            time = TimeCoeff*10 + time;
+        } 
+
         data.addInt(date);
         data.addUInt(time);
         data.addInt(0);


### PR DESCRIPTION
The used formula can result in negative time value (e.g.
1938-12-29T17:00:00.000Z gives negative time) . In this case we need to
adjust both date and time.