### PR TITLE
fix for non-ascii characters - use precalculated length in bytes

### DIFF
--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -249,9 +249,9 @@ XdrWriter.prototype.addInt = function (value) {
 XdrWriter.prototype.addInt64 = function (value) {
     this.ensure(8);
     var l = Long.fromNumber(value);
-    this.buffer.writeInt32BE(l.high_, this.pos);
+    this.buffer.writeInt32BE(l.high, this.pos);
     this.pos += 4;
-    this.buffer.writeInt32BE(l.low_, this.pos);
+    this.buffer.writeInt32BE(l.low, this.pos);
     this.pos += 4;
 };
 

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -98,7 +98,7 @@ BlrWriter.prototype.addString = function (c, s, encoding) {
     this.ensure(len + 1);
     this.buffer.writeUInt8(len, this.pos);
     this.pos++;
-    this.buffer.write(s, this.pos, s.length, encoding);
+    this.buffer.write(s, this.pos, len, encoding);
     this.pos += len;
 };
 
@@ -119,7 +119,7 @@ BlrWriter.prototype.addString2 = function (c, s, encoding) {
     this.ensure(len + 2);
     this.buffer.writeUInt16LE(len, this.pos);
     this.pos += 2;
-    this.buffer.write(s, this.pos, s.length, encoding);
+    this.buffer.write(s, this.pos, len, encoding);
     this.pos += len;
 };
 


### PR DESCRIPTION
Hi!
You did it right here:
https://github.com/hgourvest/node-firebird/blob/master/lib/serialize.js#L270
and here:
https://github.com/hgourvest/node-firebird/blob/master/lib/serialize.js#L278
However 2 more `byteLength`-related places need fixes.