### PR TITLE
Fix node-firebird date escape bug, causing query to fail since firebi…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -776,7 +776,7 @@ exports.escape = function(value) {
     }
 
     if (value instanceof Date)
-        return "'" + value.getFullYear() + '-' + value.getMonth().toString().padLeft(2, '0') + '-' + value.getDate().toString().padLeft(2, '0') + ' ' + value.getHours().toString().padLeft(2, '0') + ':' + value.getMinutes().toString().padLeft(2, '0') + ':' + value.getSeconds().toString().padLeft(2, '0') + "'";
+        return "'" + value.getFullYear() + '-' + (value.getMonth()+1).toString().padLeft(2, '0') + '-' + value.getDate().toString().padLeft(2, '0') + ' ' + value.getHours().toString().padLeft(2, '0') + ':' + value.getMinutes().toString().padLeft(2, '0') + ':' + value.getSeconds().toString().padLeft(2, '0') + "'";
 
     throw new Error('Escape supports only primitive values.');
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -776,7 +776,7 @@ exports.escape = function(value) {
     }
 
     if (value instanceof Date)
-        return "'" + value.getFullYear() + '-' + (value.getMonth()+1).toString().padLeft(2, '0') + '-' + value.getDate().toString().padLeft(2, '0') + ' ' + value.getHours().toString().padLeft(2, '0') + ':' + value.getMinutes().toString().padLeft(2, '0') + ':' + value.getSeconds().toString().padLeft(2, '0') + "'";
+        return "'" + value.getFullYear() + '-' + (value.getMonth()+1).toString().padLeft(2, '0') + '-' + value.getDate().toString().padLeft(2, '0') + ' ' + value.getHours().toString().padLeft(2, '0') + ':' + value.getMinutes().toString().padLeft(2, '0') + ':' + value.getSeconds().toString().padLeft(2, '0') + '.' + value.getMilliseconds().toString().padLeft(3, '0') + "'";
 
     throw new Error('Escape supports only primitive values.');
 };


### PR DESCRIPTION
Fix node-firebird date escape bug, causing query to fail since firebird starts numbering of months at 1 instad of 0 like javascript.

Queries created using the escape method are failing for the month of January and lag a month behind for other dates.

This fix addresses those concerns and fixes the type conversion.

Also add millisecond support to escaped dates for compatibility with Firebird.
