### PR TITLE
Close firebird.msg synchronously

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -147,7 +147,7 @@ exports.lookupMessages = function(status, callback){
                         text = line;
 
                     if (i === status.length - 1) {
-                        fs.close(handle);
+                        fs.closeSync(handle);
                         callback(text);
                     } else {
                         i++;


### PR DESCRIPTION
As of node 7.4.0, any database error will print the following message to the console, because `fs.close()` is run without a callback:

`DeprecationWarning: Calling an asynchronous function without callback is deprecated.`

Changing `fs.close()` to `fs.closeSync()` removes this warning.

Example to run to see this message printed to the console:

```javascript
var Firebird = require('node-firebird');
Firebird.attach({database:'path/to/database.fdb'}, function (err, db) {
	if(err) throw err;
	db.query('BADQUERY', function(err, result) {
		if(err) throw err; //Before printing the error, node prints the deprecation warning.
		console.log(result);
	});
});
```