### PR TITLE
Set buffer.toString encoding to 'undefined' explicitly

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -92,7 +92,7 @@ exports.lookupMessages = function(status, callback){
 
                 if (ret.code == code){
                     from += 8;
-                    ret.text = buffer.toString(null, from, from + ret.length);
+                    ret.text = buffer.toString(undefined, from, from + ret.length);
                 } else
                     ret.seek = from + align(8 + ret.length, 4);
 


### PR DESCRIPTION
Since node 8, `null` can no longer be used as the encoding argument for `Buffer.toString`
```
$ node -v && node
v7.9.0
> Buffer.from('foo').toString(null)
'foo'
```
```
$ node -v && node
v8.0.0
> Buffer.from('foo').toString(null)
TypeError: Unknown encoding: null
```
I changed the offending line so it passed `undefined` instead