### PR TITLE
Typescript definition file.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ declare module 'node-firebird' {
     type TransactionCallback = (err: Options, transaction: Transaction) => void;
     type QueryCallback = (err: any, result: any[]) => void;
     type SimpleCallback = (err: any) => void;
+    type SequentialCallback = (row: any, index: number) => void;
 
     export const ISOLATION_READ_UNCOMMITTED: number[];
     export const ISOLATION_READ_COMMITED: number[];
@@ -20,6 +21,9 @@ declare module 'node-firebird' {
     export interface Database {
         detach(callback?: SimpleCallback): void;
         transaction(isolation: Isolation, callback: TransactionCallback): void;
+        query(query: string, params: any[], callback: QueryCallback): void;
+        execute(query: string, params: any[], callback: QueryCallback): void;
+        sequentially(query: string, params: any[], rowCallback: SequentialCallback, callback: SimpleCallback): void;
     }
 
     export interface Transaction {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for node-firebird 0.8.3
+// Project: node-firebird
+// Definitions by: Marco Warm <https://github.com/MarcusCalidus>
+
+declare module 'node-firebird' {
+    type AttachCallback = (err: any, db: Database) => void;
+
+    type TransactionCallback = (err: Options, transaction: Transaction) => void;
+    type QueryCallback = (err: any, result: any[]) => void;
+    type SimpleCallback = (err: any) => void;
+
+    export const ISOLATION_READ_UNCOMMITTED: number[];
+    export const ISOLATION_READ_COMMITED: number[];
+    export const ISOLATION_REPEATABLE_READ: number[];
+    export const ISOLATION_SERIALIZABLE: number[];
+    export const ISOLATION_READ_COMMITED_READ_ONLY: number[];
+
+    export type Isolation = number[];
+
+    export interface Database {
+        detach(callback?: SimpleCallback): void;
+        transaction(isolation: Isolation, callback: TransactionCallback): void;
+    }
+
+    export interface Transaction {
+        query(query: string, params: any[], callback: QueryCallback): void;
+        execute(query: string, params: any[], callback: QueryCallback): void;
+        commit(callback?: SimpleCallback): void;
+        rollback(callback?: SimpleCallback): void; 
+    }
+
+    export interface Options {
+        host?: string;
+        port?: number;
+        database?: string;
+        user?: string;
+        password?: string;
+        lowercase_keys?: boolean;
+        role?: string;           
+        pageSize?: number; 
+    }
+    
+    export function attach(options: any, callback: AttachCallback): void; 
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Marco Warm <https://github.com/MarcusCalidus>
 
 declare module 'node-firebird' {
-    type AttachCallback = (err: any, db: Database) => void;
+    type DatabaseCallback = (err: any, db: Database) => void;
 
     type TransactionCallback = (err: Options, transaction: Transaction) => void;
     type QueryCallback = (err: any, result: any[]) => void;
@@ -43,6 +43,15 @@ declare module 'node-firebird' {
         role?: string;           
         pageSize?: number; 
     }
+
+    export interface ConnectionPool {
+        get(callback: DatabaseCallback): void;
+        destroy(): void; 
+    }
     
-    export function attach(options: any, callback: AttachCallback): void; 
+    export function attach(options: Options, callback: DatabaseCallback): void; 
+    export function escape(value: string): string;
+    export function create(options: Options, callback: DatabaseCallback): void; 
+    export function attachOrCreate(options: Options, callback: DatabaseCallback): void;
+    export function pool(max: number,options: Options, callback: DatabaseCallback): ConnectionPool; 
 }

--- a/package.json
+++ b/package.json
@@ -1,34 +1,32 @@
 {
-  "name": "node-firebird",
-  "version": "0.8.3",
-  "description": "Pure JavaScript and Asynchronous Firebird client for Node.js.",
-  "keywords": [
-    "firebird",
-    "database",
-    "rdbms",
-    "sql"
-  ],
-  "homepage": "https://github.com/hgourvest/node-firebird",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/hgourvest/node-firebird"
-  },
-  "author": {
-    "name": "Henri Gourvest",
-    "email": "hgourvest@gmail.com"
-  },
-  "contributors": [
-      "Popa Marius Adrian <mapopa@gmail.com>",
-      "Peter \u0160irka <petersirka@gmail.com>"
-  ],
-  "main": "./lib",
-  "licenses" : [
-    {
-      "type" : "MPL-2.0",
-      "url": "https://raw.githubusercontent.com/hgourvest/node-firebird/master/LICENSE"
+    "name": "node-firebird",
+    "version": "0.8.4-alpha0",
+    "description": "Pure JavaScript and Asynchronous Firebird client for Node.js.",
+    "keywords": [
+        "firebird",
+        "database",
+        "rdbms",
+        "sql"
+    ],
+    "homepage": "https://github.com/hgourvest/node-firebird",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/hgourvest/node-firebird"
+    },
+    "author": {
+        "name": "Henri Gourvest",
+        "email": "hgourvest@gmail.com"
+    },
+    "contributors": [
+        "Popa Marius Adrian <mapopa@gmail.com>",
+        "Peter \u0160irka <petersirka@gmail.com>"
+    ],
+    "main": "./lib",
+    "licenses": [{
+        "type": "MPL-2.0",
+        "url": "https://raw.githubusercontent.com/hgourvest/node-firebird/master/LICENSE"
+    }],
+    "dependencies": {
+        "long": "^2.2.5"
     }
-  ],
-  "dependencies": {
-      "long": "^2.2.5"
-  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-firebird",
-    "version": "0.8.4-alpha0",
+    "version": "0.8.3",
     "description": "Pure JavaScript and Asynchronous Firebird client for Node.js.",
     "keywords": [
         "firebird",


### PR DESCRIPTION
In the attempt of using node-firebird within our existing typescript projects there was the need to include a typescript definition file. It does not contain the full range of all functions. Only those we needed in our project. But for a start it might suffice. 
ToDo: add Blob functions

correct syntax for typescript include:

`import * as Firebird from 'node-firebird';`
`import { Options, ISOLATION_READ_COMMITED, Isolation, Transaction } from 'node-firebird';`

simple script exec example in typescript:

`Firebird.attach(this.options, (err: any, db: Firebird.Database) => {`
`            db.execute(`
`                'execute procedure My_Super_Function', `
`                [], `
`                (err) => {`
`                    if (err) { console.error(err); }`
`                    db.detach((err) => {`
`                        if (err) { console.error(err); }`
`                    });`
`                })`
`        });`