### PR TITLE
Prevent uncaught exception when database is not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ var Firebird = require('node-firebird');
 - `Firebird.attachOrCreate(options, function(err, db))` attach or create database
 - `Firebird.pool(max, options, function(err, db)) -> return {Object}` create a connection pooling
 
-## Connection types
+## Connection types
 
 ### Connection options
 
@@ -131,7 +131,7 @@ pool.destroy();
 
 ### PARAMETRIZED QUERIES
 
-### Parameters
+### Parameters
 
 ```js
 Firebird.attach(options, function(err, db) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3156,9 +3156,9 @@ Connection.prototype.attach = function (options, callback, db) {
     this._lowercase_keys = options.lowercase_keys || DEFAULT_LOWERCASE_KEYS;
     
     var database = options.database || options.filename;
-    
     if (database == null || database.length == 0) {
-        doError(new Error('No database specified.'), callback);
+        doError(new Error('No database specified'), callback);
+        return;
     }
     
     var user = options.user || DEFAULT_USER;
@@ -3236,9 +3236,9 @@ Connection.prototype.detach = function (callback) {
 Connection.prototype.createDatabase = function (options, callback) {
 
     var database = options.database || options.filename;
-    
     if (database == null || database.length == 0) {
-        doError(new Error('No database specified.'), callback);
+        doError(new Error('No database specified'), callback);
+        return;
     }
     
     var user = options.user || DEFAULT_USER;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3154,7 +3154,13 @@ Connection.prototype.connect = function (database, callback) {
 
 Connection.prototype.attach = function (options, callback, db) {
     this._lowercase_keys = options.lowercase_keys || DEFAULT_LOWERCASE_KEYS;
+    
     var database = options.database || options.filename;
+    
+    if (database == null || database.length == 0) {
+        doError(new Error('No database specified.'), callback);
+    }
+    
     var user = options.user || DEFAULT_USER;
     var password = options.password || DEFAULT_PASSWORD;
     var role = options.role;
@@ -3230,6 +3236,11 @@ Connection.prototype.detach = function (callback) {
 Connection.prototype.createDatabase = function (options, callback) {
 
     var database = options.database || options.filename;
+    
+    if (database == null || database.length == 0) {
+        doError(new Error('No database specified.'), callback);
+    }
+    
     var user = options.user || DEFAULT_USER;
     var password = options.password || DEFAULT_PASSWORD;
     var pageSize = options.pageSize || DEFAULT_PAGE_SIZE;


### PR DESCRIPTION
Currently if you try to `attach` or `create` without specifying a `database`, the process will throw an uncaught exception.

```javascript
var Firebird = require('node-firebird');
Firebird.attach({}, function () {});
```

```bash
buffer.js:481
    throw new TypeError('"string" must be a string, Buffer, or ArrayBuffer');
    ^

TypeError: "string" must be a string, Buffer, or ArrayBuffer
    at Function.byteLength (buffer.js:481:11)
    at exports.XdrWriter.XdrWriter.addString (/home/ben/Git/firebird-test/node_modules/node-firebird/lib/serialize.js:265:22)
    at exports.Connection.Connection.createDatabase (/home/ben/Git/firebird-test/node_modules/node-firebird/lib/index.js:3258:9)
    at /home/ben/Git/firebird-test/node_modules/node-firebird/lib/index.js:1613:17
    at doCallback (/home/ben/Git/firebird-test/node_modules/node-firebird/lib/index.js:1238:5)
    at Socket.<anonymous> (/home/ben/Git/firebird-test/node_modules/node-firebird/lib/index.js:2933:17)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at addChunk (_stream_readable.js:263:12)
    at readableAddChunk (_stream_readable.js:250:11)
```
I've added checks to throw an error properly when the `database` is not specified for `attach` or `create`.

Also removed some formatting symbols in the `README.md` that were preventing a couple headers from rendering.