### PR TITLE
Fix TypeError: "self.emit is not a function"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2847,14 +2847,14 @@ exports.Connection.prototype._bind_events = function(host, port, callback) {
                 ctx.connect(self.options.filename, function(err) {
 
                     if (err) {
-                        self.emit('error', err);
+                        self.db.emit('error', err);
                         return;
                     }
 
                     ctx.attach(self.options, function(err) {
 
                         if (err) {
-                            self.emit('error', err);
+                            self.db.emit('error', err);
                             return;
                         }
 


### PR DESCRIPTION
The error was due to calling self.emit("error", err); instead of self.db.emit("error", err).
There may be other error when calling self.emit("detach", false) in index.