### PR TITLE
Issue #182 - Parameterize the location of firebird.msg

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2879,6 +2879,7 @@ var Connection = exports.Connection = function (host, port, callback, options, d
     this.error;
     this._max_cached_query = options.maxCachedQuery || -1;
     this._cache_query = options.cacheQuery?{}:null;
+    this._messageFile = options.messageFile || __dirname + "/firebird.msg";
 };
 
 exports.Connection.prototype._setcachedquery = function (query, statement) {
@@ -3005,7 +3006,7 @@ exports.Connection.prototype._bind_events = function(host, port, callback) {
 
             if (obj && obj.status) {
 
-                messages.lookupMessages(obj.status, function(message) {
+                messages.lookupMessages(obj.status, self._messageFile, function(message) {
                     obj.message = message;
                     doCallback(obj, cb);
                 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,8 @@ var
     BlrWriter = serialize.BlrWriter,
 	BitSet = serialize.BitSet,
     messages = require('./messages.js'),
-	crypt = require('./unix-crypt.js');
+    crypt = require('./unix-crypt.js'),
+    path = require('path');
 
 if (typeof(setImmediate) === 'undefined') {
     global.setImmediate = function(cb) {
@@ -2879,7 +2880,7 @@ var Connection = exports.Connection = function (host, port, callback, options, d
     this.error;
     this._max_cached_query = options.maxCachedQuery || -1;
     this._cache_query = options.cacheQuery?{}:null;
-    this._messageFile = options.messageFile || __dirname + "/firebird.msg";
+    this._messageFile = options.messageFile || path.join(__dirname, 'firebird.msg');
 };
 
 exports.Connection.prototype._setcachedquery = function (query, statement) {

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -22,7 +22,7 @@ exports.getClass = function(code) {
     return (code & CLASS_MASK) >> 30
 };
 
-exports.lookupMessages = function(status, callback){
+exports.lookupMessages = function(status, messageFile, callback){
 
     var handle;
     var bucket_size;
@@ -120,7 +120,7 @@ exports.lookupMessages = function(status, callback){
         readIndex(1, top_tree);
     }
 
-    fs.open(__dirname + "/firebird.msg", 'r', function(err, h) {
+    fs.open(messageFile, 'r', function(err, h) {
 
         if (!h) {
             callback();


### PR DESCRIPTION
firebird.msg is included inside the module dir, and for most of the
cases, it is enough, since the node_modules follow the application.
But in some specific cases, such as on packing the application with
Electron (and probably any Webpack packaging), the file is not
included by default. Moreover, in electron, there are restrictions
on where the file can be placed. An extra option was included to
define where the firebird.msg is placed. By default, the file will be
load from the same old place.

Closes hgourvest/node-firebird#182