### PR TITLE
Corrections for reading empty blobs and varchar charset none

### DIFF
--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -224,7 +224,7 @@ BlrReader.prototype.readSegment = function() {
         this.pos += 2;
     }
 
-    return ret;
+    return ret ? ret : Buffer.alloc(0);
 };
 
 /***************************************
@@ -401,16 +401,21 @@ XdrReader.prototype.readArray = function () {
     return r;
 };
 
-XdrReader.prototype.readBuffer = function(len, toAlign = true) {
-    if (!arguments.length)
-       len = this.readInt();
+XdrReader.prototype.readBuffer = function (len, toAlign = true) {
+    if (!arguments.length) {
+        len = this.readInt();
+    }
 
-    if (!len)
-        return;
+    if (len !== null && len !== undefined) {
 
-    var r = this.buffer.slice(this.pos, this.pos + len);
-    this.pos += toAlign ? align(len) : len;
-    return r;
+        if (len <= 0){
+            return Buffer.alloc(0);
+        }
+
+        var r = this.buffer.slice(this.pos, this.pos + len);
+        this.pos += toAlign ? align(len) : len;
+        return r;
+    }
 };
 
 XdrReader.prototype.readString = function(encoding) {


### PR DESCRIPTION
Corrections for reading empty blobs fields and also for empty varchar fields of type charset none returning undefined