### PR TITLE
Adding ServiceManager typescript definitions; and fixing typos and potential bugs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ var Firebird = require('node-firebird');
 - `Firebird.attach(options, function(err, db))` attach a database
 - `Firebird.create(options, function(err, db))` create a database
 - `Firebird.attachOrCreate(options, function(err, db))` attach or create database
-- `Firebird.pool(max, options, function(err, db)) -> return {Object}` create a connection pooling
+- `Firebird.pool(max, options) -> return {Object}` create a connection pooling
 
 ## Connection types
 
@@ -402,7 +402,7 @@ var fbsvc = {
 ### Backup Service example
 
 ```js
-
+const options = {...}; // Classic configuration with manager = true
 Firebird.attach(options, function(err, svc) {
     if (err)
         return;
@@ -417,14 +417,17 @@ Firebird.attach(options, function(err, svc) {
                    ]
         },
         function(err, data) {
-            console.log(data);
-        });
+            data.on('data', line => console.log(line));
+            data.on('end', () => svc.detach());
+        }
+    );
+});
 ```
 
 ### Restore Service example
 
 ```js
-const config = {...}; // Clasic configuration with manager = true
+const config = {...}; // Classic configuration with manager = true
 const RESTORE_OPTS = {
     database: 'database.fdb',
     files: ['backup.fbk']

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -4,8 +4,7 @@
 
 declare module 'node-firebird' {
     type DatabaseCallback = (err: any, db: Database) => void;
-
-    type TransactionCallback = (err: Options, transaction: Transaction) => void;
+    type TransactionCallback = (err: any, transaction: Transaction) => void;
     type QueryCallback = (err: any, result: any[]) => void;
     type SimpleCallback = (err: any) => void;
     type SequentialCallback = (row: any, index: number) => void;
@@ -19,18 +18,20 @@ declare module 'node-firebird' {
     export type Isolation = number[];
 
     export interface Database {
-        detach(callback?: SimpleCallback): void;
-        transaction(isolation: Isolation, callback: TransactionCallback): void;
-        query(query: string, params: any[], callback: QueryCallback): void;
-        execute(query: string, params: any[], callback: QueryCallback): void;
-        sequentially(query: string, params: any[], rowCallback: SequentialCallback, callback: SimpleCallback): void;
+        detach(callback?: SimpleCallback): Database;
+        transaction(isolation: Isolation, callback: TransactionCallback): Database;
+        query(query: string, params: any[], callback: QueryCallback): Database;
+        execute(query: string, params: any[], callback: QueryCallback): Database;
+        sequentially(query: string, params: any[], rowCallback: SequentialCallback, callback: SimpleCallback, asArray?: boolean): Database;
+        drop(callback: SimpleCallback): void;
+        escape(value: any): string;
     }
 
     export interface Transaction {
         query(query: string, params: any[], callback: QueryCallback): void;
         execute(query: string, params: any[], callback: QueryCallback): void;
         commit(callback?: SimpleCallback): void;
-        rollback(callback?: SimpleCallback): void; 
+        rollback(callback?: SimpleCallback): void;
     }
 
     export interface Options {
@@ -40,18 +41,200 @@ declare module 'node-firebird' {
         user?: string;
         password?: string;
         lowercase_keys?: boolean;
-        role?: string;           
-        pageSize?: number; 
+        role?: string;
+        pageSize?: number;
+    }
+
+    export interface SvcMgrOptions extends Options {
+        manager: true; // Attach to ServiceManager
     }
 
     export interface ConnectionPool {
         get(callback: DatabaseCallback): void;
-        destroy(): void; 
+        destroy(): void;
     }
-    
-    export function attach(options: Options, callback: DatabaseCallback): void; 
-    export function escape(value: string): string;
-    export function create(options: Options, callback: DatabaseCallback): void; 
+
+    export function attach(options: Options, callback: DatabaseCallback): void;
+    export function attach(options: SvcMgrOptions, callback: ServiceManagerCallback): void;
+    export function escape(value: any): string;
+    export function create(options: Options, callback: DatabaseCallback): void;
     export function attachOrCreate(options: Options, callback: DatabaseCallback): void;
-    export function pool(max: number,options: Options, callback: DatabaseCallback): ConnectionPool; 
+    export function pool(max: number, options: Options): ConnectionPool;
+    export function drop(options: Options, callback: SimpleCallback): void;
+
+    interface ReadableOptions {
+        optread?: 'byline' | 'buffer'; // default 'byline'
+        buffersize?: number; // default 'byline': 2048, 'buffer': 8192
+        timeout?: number;
+    }
+
+    export interface BackupOptions extends ReadableOptions {
+        database?: string;
+        files: string | { filename: string, sizefile: string }[];
+        factor?: number; // If backing up to a physical tape device, this switch lets you specify the tape's blocking factor
+        verbose?: boolean;
+        ignorechecksums?: boolean;
+        ignorelimbo?: boolean;
+        metadataonly?: boolean;
+        nogarbasecollect?: boolean;
+        olddescriptions?: boolean;
+        nontransportable?: boolean;
+        convert?: boolean;
+        expand?: boolean;
+        notriggers?: boolean;
+    }
+
+    export interface NBackupOptions extends ReadableOptions {
+        database?: string;
+        file: string;
+        level?: number; // nb day for incremental
+        notriggers?: boolean;
+        direct?: 'on' | 'off'; // default 'on'
+    }
+
+    export interface RestoreOptions extends ReadableOptions {
+        database?: string;
+        files: string | string[];
+        verbose?: boolean;
+        cachebuffers?: number; // default 2048, gbak -buffers
+        pagesize?: boolean; // default 4096
+        readonly?: boolean; // default false
+        deactivateindexes?: boolean; // default false
+        noshadow?: boolean; // default false
+        novalidity?: boolean; // default false
+        individualcommit?: boolean; // default true
+        replace?: boolean; // default false
+        create?: boolean; // default true
+        useallspace?: boolean; // default false
+        metadataonly?: boolean; // default false
+        fixfssdata?: string; // default null
+        fixfssmetadata?: string; // default null
+    }
+
+    export interface NRestoreOptions extends ReadableOptions {
+        database?: string;
+        files: string | string[];
+    }
+
+    export interface ValidateOptions extends ReadableOptions {
+        database?: string;
+        checkdb?: boolean;
+        ignorechecksums?: boolean;
+        killshadows?: boolean;
+        mend?: boolean;
+        validate?: boolean;
+        full?: boolean;
+        sweep?: boolean;
+        listlimbo?: boolean;
+        icu?: boolean;
+    }
+
+    export interface StatsOptions extends ReadableOptions {
+        database?: string;
+        record?: boolean;
+        nocreation?: boolean;
+        tables?: boolean;
+        pages?: boolean;
+        header?: boolean;
+        indexes?: boolean;
+        tablesystem?: boolean;
+        encryption?: boolean;
+        objects?: string; // space-separated list of object index,table,systemtable
+    }
+
+    interface UserInfo {
+        userid: number;
+        groupid: number;
+        username: string;
+        firstname: string;
+        middlename: string;
+        lastname: string
+        admin: number;
+        rolename?: string;
+        groupname?: string;
+    }
+
+    export interface ServerInfo {
+        result: number;
+        dbinfo?: { database: any[], nbattachment: number, nbdatabase: number };
+        fbconfig?: any;
+        svcversion?: number;
+        fbversion?: string;
+        fbimplementation?: string;
+        fbcapatibilities: string[];
+        pathsecuritydb?: string;
+        fbenv?: string;
+        fbenvlock?: string;
+        fbenvmsg?: string;
+        limbotrans?: number[];
+        fbusers?: UserInfo[]
+    }
+
+    export interface ServerInfoReq {
+        dbinfo?: boolean;
+        fbconfig?: boolean;
+        svcversion?: boolean;
+        fbversion?: boolean;
+        fbimplementation?: boolean;
+        fbcapatibilities?: boolean;
+        pathsecuritydb?: boolean;
+        fbenv?: boolean;
+        fbenvlock?: boolean;
+        fbenvmsg?: boolean;
+        limbotrans?: boolean;
+    }
+
+    export interface TraceOptions extends ReadableOptions {
+        configfile?: string; // startTrace uses it
+        tracename?: string; // startTrace uses it
+        traceid?: number; // suspendTrace, stopTrace, and resumeTrace use it
+    }
+
+    type ServiceManagerCallback = (err: any, svc: ServiceManager) => void;
+    type ReadableCallback = (err: any, reader: NodeJS.ReadableStream) => void;
+    type InfoCallback = (err: any, info: ServerInfo) => void;
+    type LineCallback = (err: any, data: { result: number, line: string }) => void;
+
+    export enum ShutdownMode { NORMAL = 0, MULTI = 1, SINGLE = 2, FULL = 3 }
+    export enum ShutdownKind { FORCED = 0, DENY_TRANSACTION = 1, DENY_ATTACHMENT = 2 }
+
+    export interface ServiceManager {
+        detach(callback?: SimpleCallback, force?: boolean): void;
+        backup(options: BackupOptions, callback: ReadableCallback): void;
+        nbackup(options: BackupOptions, callback: ReadableCallback): void;
+        restore(options: NRestoreOptions, callback: ReadableCallback): void;
+        nrestore(options, callback): void;
+        setDialect(db: string, dialect: 1 | 3, callback: ReadableCallback): void;
+        setSweepinterval(db: string, interval: number, callback): void; // gfix -h INTERVAL
+        setCachebuffer(db: string, nbpages, callback: ReadableCallback): void; // gfix -b NBPAGES
+        BringOnline(db: string, callback: ReadableCallback): void; // gfix -o
+        Shutdown(db: string, kind: ShutdownKind, delay: number, mode: ShutdownMode, callback: ReadableCallback): void; // server version >= 2.0
+        Shutdown(db: string, kind: ShutdownKind, delay: number, callback: ReadableCallback): void; // server version < 2.0
+        setShadow(db: string, val: boolean, callback: ReadableCallback): void;
+        setForcewrite(db: string, val: boolean, callback: ReadableCallback): void; // gfix -write
+        setReservespace(db: string, val: boolean, callback: ReadableCallback): void; // true: gfix -use reserve, false: gfix -use full
+        setReadonlyMode(db: string, callback: ReadableCallback): void; //  gfix -mode read_only 
+        setReadwriteMode(db: string, callback: ReadableCallback): void; //  gfix -mode read_write 
+        validate(options: ValidateOptions, callback: ReadableCallback): void; // gfix -validate
+        commit(db: string, transactid: number, callback: ReadableCallback): void; // gfix -commit
+        rollback(db: string, transactid: number, callback: ReadableCallback): void;
+        recover(db: string, transactid: number, callback: ReadableCallback): void;
+        getStats(options: StatsOptions, callback: ReadableCallback): void;
+        getLog(options: ReadableOptions, callback: ReadableCallback): void;
+        getUsers(username: string | null, callback: InfoCallback): void;
+        addUser(username: string, password: string, info: UserInfo, callback: ReadableCallback): void;
+        editUser(username: string, info: UserInfo, callback: ReadableCallback): void;
+        removeUser(username: string, rolename: string | null, callback: ReadableCallback): void;
+        getFbserverInfos(infos: ServerInfoReq, options: { buffersize?: number, timeout?: number }, callback: InfoCallback): void; // if infos is empty all options are asked to the service
+        startTrace(options: TraceOptions, callback: ReadableCallback): void;
+        suspendTrace(options: TraceOptions, callback: ReadableCallback): void;
+        resumeTrace(options: TraceOptions, callback: ReadableCallback): void;
+        stopTrace(options: TraceOptions, callback: ReadableCallback): void;
+        getTraceList(options: ReadableOptions, callback: ReadableCallback): void;
+        readline(options: ReadableOptions, callback: LineCallback): void;
+        readeof(options: ReadableOptions, callback: LineCallback): void;
+        hasRunningAction(options: ReadableOptions, callback: ReadableCallback): void;
+        readusers(options: ReadableOptions, callback: ReadableCallback): void;
+        readlimbo(options: ReadableOptions, callback: ReadableCallback): void;
+    }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1379,6 +1379,7 @@ Transaction.prototype.newStatement = function(query, callback) {
 Transaction.prototype.execute = function(query, params, callback, custom) {
 
     if (params instanceof Function) {
+        custom = callback;
         callback = params;
         params = undefined;
     }
@@ -1572,6 +1573,7 @@ Database.prototype.newStatement = function (query, callback) {
 Database.prototype.execute = function(query, params, callback, custom) {
 
     if (params instanceof Function) {
+        custom = callback;
         callback = params;
         params = undefined;
     }
@@ -1793,7 +1795,7 @@ ServiceManager.prototype._infosmapping = {
     "63"/*isc_info_svc_to_eof*/ : "",
     "64"/*isc_info_svc_timeout*/ : "",
     "65"/*isc_info_svc_get_licensed_users*/ : "",
-    "66"/*isc_info_svc_limbo_trans*/ : "",
+    "66"/*isc_info_svc_limbo_trans*/ : "limbotrans",
     "67"/*isc_info_svc_running*/ : "",
     "68"/*isc_info_svc_get_users*/ : "fbusers",
     "78"/*isc_info_svc_stdin*/ : ""
@@ -2175,11 +2177,11 @@ ServiceManager.prototype._fixpropertie = function (options, callback) {
     var online = options.bringonline || false;
     var shutdown = options.shutdown != null ? options.shutdown : null; // 0 Forced, 1 deny transaction, 2 deny attachment
     var shutdowndelay = options.shutdowndelay || 0;
-    var shutdownmode = options.shutdownmode != null ? options.shutdownmode : null; // 0 normal 1 multi 2 single 3 full
+    var shutdownmode = options.shutdownmode; // 0 normal 1 multi 2 single 3 full
     var shadow = options.activateshadow || false;
-    var forcewrite = options.forcewrite!=null?options.forcewrite:null;
-    var reservespace = options.reservespace!=null?options.reservespace:null;
-    var accessmode = options.accessmode!=null?options.accessmode:null; // 0 readonly 1 readwrite
+    var forcewrite = options.forcewrite;
+    var reservespace = options.reservespace;
+    var accessmode = options.accessmode; // 0 readonly 1 readwrite
 
     if (dbpath == null || dbpath.length === 0) {
         doError(new Error('No database specified'), callback);
@@ -2213,9 +2215,9 @@ ServiceManager.prototype._fixpropertie = function (options, callback) {
 		}
     }
     if (forcewrite) blr.addBytes([isc_spb_prp_write_mode, isc_spb_prp_wm_sync]);
-    if (forcewrite != null && !forcewrite) blr.addBytes([isc_spb_prp_write_mode, isc_spb_prp_wm_async]);
-    if (accessmode) blr.addBytes([isc_spb_prp_access_mode, isc_spb_prp_am_readwrite]);
-    if (accessmode != null && !accessmode) blr.addBytes([isc_spb_prp_access_mode, isc_spb_prp_am_readonly]);
+    if (forcewrite === false) blr.addBytes([isc_spb_prp_write_mode, isc_spb_prp_wm_async]);
+    if (accessmode === 1) blr.addBytes([isc_spb_prp_access_mode, isc_spb_prp_am_readwrite]);
+    if (accessmode === 0) blr.addBytes([isc_spb_prp_access_mode, isc_spb_prp_am_readonly]);
     if (reservespace) blr.addBytes([isc_spb_prp_reserve_space, isc_spb_prp_res]);
     if (reservespace != null && !reservespace) blr.addBytes([isc_spb_prp_reserve_space, isc_spb_prp_res_use_full]);
     var opts = 0;
@@ -2265,6 +2267,11 @@ const SHUTDOWNEX_MODE = {
 	2: isc_spb_prp_sm_single,
 	3: isc_spb_prp_sm_full
 };
+const ShutdownMode = { NORMAL: 0, MULTI: 1, SINGLE: 2, FULL: 3 };
+const ShutdownKind = { FORCED: 0, DENY_TRANSACTION: 1, DENY_ATTACHMENT: 2 };
+exports.ShutdownMode = ShutdownMode;
+exports.ShutdownKind = ShutdownKind;
+
 ServiceManager.prototype.Shutdown = function (db, kind, delay, mode, callback) {
     // mode parameter is for server version >= 2.0
 	if (mode instanceof Function) {
@@ -2355,7 +2362,7 @@ ServiceManager.prototype.commit = function(db, transactid, callback) {
             doError(new Error(err), callback);
             return;
         }
-        self._createOutputStream(options.optread, options.buffersize, callback);
+        self._createOutputStream(null, null, callback);
     });
 }
 
@@ -2376,7 +2383,7 @@ ServiceManager.prototype.rollback = function (db, transactid, callback) {
             doError(new Error(err), callback);
             return;
         }
-        self._createOutputStream(options.optread, options.buffersize, callback);
+        self._createOutputStream(null, null, callback);
     });
 }
 
@@ -2397,7 +2404,7 @@ ServiceManager.prototype.recover = function (db, transactid, callback) {
             doError(new Error(err), callback);
             return;
         }
-        self._createOutputStream(options.optread, options.buffersize, callback);
+        self._createOutputStream(null, null, callback);
     });
 }
 
@@ -2576,11 +2583,10 @@ ServiceManager.prototype.getFbserverInfos = function (infos, options, callback) 
     };
     // if infos is empty all options are asked to the service
 
-    var tops = [];
+    var tops = [], empty = isEmpty(infos);
     for (popts in opts)
-        if (infos[popts] || infos.length == 0)
+        if (empty || infos[popts])
             tops.push(opts[popts]);
-
 
     var self = this;
     this.connection.svcquery(tops, buffersize, timeout, function (err, data) {
@@ -2590,6 +2596,11 @@ ServiceManager.prototype.getFbserverInfos = function (infos, options, callback) 
         }
         self._processquery(data.buffer, callback);
     });
+}
+
+function isEmpty(obj){
+    for(var p in obj) return false;
+    return true;
 }
 
 ServiceManager.prototype.startTrace = function (options, callback) {
@@ -2689,7 +2700,6 @@ ServiceManager.prototype.stopTrace = function (options, callback) {
 ServiceManager.prototype.getTraceList = function (options, callback) {
     var self = this;
     var blr = this.connection._blr;
-    var optread = options.optread || 'byline';
     blr.pos = 0;
     blr.addByte(isc_action_svc_trace_list);
     this.connection.svcstart(blr, function (err, data) {
@@ -2767,7 +2777,7 @@ ServiceManager.prototype.readlimbo = function (options, callback) {
 }
 
 // Pooling
-exports.pool = function(max, options, callback) {
+exports.pool = function(max, options) {
 	return new Pool(max, Object.assign({}, options, { isPool: true }));
 };
 
@@ -3598,11 +3608,6 @@ Connection.prototype.startTransaction = function(isolation, callback) {
     blr.pos = 0;
     msg.pos = 0;
 
-    if (isolation instanceof Function) {
-        callback = isolation;
-        isolation = null;
-    }
-
     blr.addBytes(isolation || ISOLATION_REPEATABLE_READ);
     msg.addInt(op_transaction);
     msg.addInt(this.dbhandle);
@@ -4312,12 +4317,6 @@ Connection.prototype.fetch = function(statement, transaction, count, callback) {
     msg.addBlr(blr);
     msg.addInt(0); // message number
     msg.addInt(count || DEFAULT_FETCHSIZE); // fetch count
-
-    if (!transaction) {
-        callback.statement = statement;
-        this._queueEvent(callback);
-        return;
-    }
 
     callback.statement = statement;
     this._queueEvent(callback);


### PR DESCRIPTION
This PR contains the following changes:

### index.js

| Line(s) | Description |
| -- | -- |
| 1381,1575| `params` parameter is optional, but if it wasn't sent then `custom` parameter value was being lost. |
| 1798 | added name `limbotrans` for the property that was being populated by `_processQuery` |
| 2180-2184 | Simplifying expressions: `(x != null ? x : null) <==> x` |
| 2218-2220 | The if expressions weren't considering `undefined` nor other types (strings, objects, Dates, etc.), better using `===`. |
| 2270 | Adding constants to be used as parameters of Shutdown (specially useful in typescript) |
| 2365,2386 | `options` is not defined, so these lines would throw an exception. Using null they will get their default values). |
| 2586,2588,2601 | `infos.length` will never be defined as `infos` is meant to be an object with the required properties, so better using another validation for empty object. |
| 2702 | removing `optread` as it was never used |
| 2780 | Removing `callback` parameter as `pool` wasn't using it at all. The example in the README.md wasn't sending it as well. |
| 3610 | Removing unreacheable code. The line 3593 already took care of it. |
| 4320 | Removing redundant `if`. No matter if it's true or false, the same code will be executed |

### index.d.ts

| Line(s) | Description |
| -- | -- |
| 7 | Fixed typo |
| 21-25 | Changing return type as intended in the js code. |
| 26-27 | Added methods to Database as intended in the js code. |
| 48,58 | Added new `attach` to return a `ServiceManager` instance |
| 59 | Fixed typo |
| 62 | Removed `callback` parameter from `pool`. |
| 63-240 | Added `ServiceManager` definitions |
