### PR TITLE
Add optional callback for pool destroy

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -61,7 +61,7 @@ declare module 'node-firebird' {
 
     export interface ConnectionPool {
         get(callback: DatabaseCallback): void;
-        destroy(): void;
+        destroy(callback?: SimpleCallback): void;
     }
 
     export function attach(options: Options, callback: DatabaseCallback): void;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2903,17 +2903,40 @@ Pool.prototype.check = function() {
     return self;
 };
 
-Pool.prototype.destroy = function() {
+Pool.prototype.destroy = function(callback) {
     var self = this;
-    this.internaldb.forEach(function(db) {
-        if (db.connection._pooled === false)
+
+    var connectionCount = this.internaldb.length;
+
+    if (connectionCount === 0 && callback) {
+        callback();
+    }
+
+    function detachCallback(err) {
+        if (err) {
+            if (callback) {
+                callback(err);
+            }
             return;
+        }
+
+        connectionCount--;
+        if (connectionCount === 0 && callback) {
+            callback();
+        }
+    }
+
+    this.internaldb.forEach(function(db) {
+        if (db.connection._pooled === false) {
+            detachCallback();
+            return;
+        }
         // check if the db is not free into the pool otherwise user should manual detach it
         var _db_in_pool = self.pooldb.indexOf(db);
         if (_db_in_pool !== -1) {
             self.pooldb.splice(_db_in_pool, 1);
             db.connection._pooled = false;
-            db.detach();
+            db.detach(detachCallback);
         }
     });
 };

--- a/test/index.js
+++ b/test/index.js
@@ -116,8 +116,11 @@ describe('Pooling', function () {
         pool = Firebird.pool(poolSize, config);
     });
 
-    after(function () {
-        pool.destroy();
+    after(function (done) {
+        pool.destroy(function (err) {
+            assert.ok(!err, err);
+            done();
+        });
     });
 
     it('should wait when all connections are in use', function (done) {


### PR DESCRIPTION
This MR add support for passing callback which is triggered when all the connections in pool get destroyed.

Thank you for this library! 
I really appreciate it.