### PR TITLE
Set protocolVersion as optional in escape function (TypeScript)

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -66,7 +66,7 @@ declare module 'node-firebird' {
 
     export function attach(options: Options, callback: DatabaseCallback): void;
     export function attach(options: SvcMgrOptions, callback: ServiceManagerCallback): void;
-    export function escape(value: any, protocolVersion: number /*PROTOCOL_VERSION13*/): string;
+    export function escape(value: any, protocolVersion?: number /*PROTOCOL_VERSION13*/): string;
     export function create(options: Options, callback: DatabaseCallback): void;
     export function attachOrCreate(options: Options, callback: DatabaseCallback): void;
     export function pool(max: number, options: Options): ConnectionPool;


### PR DESCRIPTION
As you can see below, it is already an optional argument, so I'm just fixing TypeScript types.

https://github.com/hgourvest/node-firebird/blob/9613cd454aeb969323d292256abed0edba0ff8eb/lib/index.js#L830-L857