### PR TITLE
Automatically reconnect to database

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ options.password = 'masterkey';
 options.lowercase_keys = false; // set to true to lowercase keys
 options.role = null;            // default
 options.pageSize = 4096;        // default when creating database
-
+options.pageSize = 4096;        // default when creating database
+options.retryConnectionInterval = 1000; // reconnect interval in case of connection drop
 ```
 
 ### Classic

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -53,6 +53,7 @@ declare module 'node-firebird' {
         lowercase_keys?: boolean;
         role?: string;
         pageSize?: number;
+        retryConnectionInterval?: number;
     }
 
     export interface SvcMgrOptions extends Options {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2959,6 +2959,7 @@ var Connection = exports.Connection = function (host, port, callback, options, d
     this._detachAuto;
     this._socket = net.createConnection(port, host);
     this._pending = [];
+    this._isOpened = false;
     this._isClosed = false;
     this._isDetach = false;
     this._isUsed = false;
@@ -2966,6 +2967,8 @@ var Connection = exports.Connection = function (host, port, callback, options, d
     this.options = options;
     this._bind_events(host, port, callback);
     this.error;
+    this._retry_connection_id;
+    this._retry_connection_interval = options.retryConnectionInterval || 1000;
     this._max_cached_query = options.maxCachedQuery || -1;
     this._cache_query = options.cacheQuery?{}:null;
     this._messageFile = options.messageFile || path.join(__dirname, 'firebird.msg');
@@ -2991,10 +2994,11 @@ exports.Connection.prototype._bind_events = function(host, port, callback) {
 
     self._socket.on('close', function() {
 
-        self._isClosed = true;
+	    if (!self._isOpened || self._isDetach) {
+		    return;
+	    }
 
-        if (self._isDetach)
-            return;
+	    self._isOpened = false;
 
         if (!self.db) {
             if (callback)
@@ -3002,10 +3006,9 @@ exports.Connection.prototype._bind_events = function(host, port, callback) {
             return;
         }
 
-        setImmediate(function() {
+       self._retry_connection_id = setTimeout(function() {
+	        self._socket.removeAllListeners();
             self._socket = null;
-            self._msg = null;
-            self._blr = null;
 
             var ctx = new Connection(host, port, function(err) {
                 ctx.connect(self.options, function(err) {
@@ -3029,8 +3032,10 @@ exports.Connection.prototype._bind_events = function(host, port, callback) {
                     }, self.db);
                 });
 
+				Object.assign(self, ctx);
+
             }, self.options, self.db);
-        });
+        }, self._retry_connection_interval);
 
     });
 
@@ -3669,6 +3674,7 @@ Connection.prototype.detach = function (callback) {
     msg.addInt(0); // Database Object ID
 
     self._queueEvent(function(err, ret) {
+    	clearTimeout(self._retry_connection_id);
         delete(self.dbhandle);
         if (callback)
             callback(err, ret);

--- a/lib/index.js
+++ b/lib/index.js
@@ -2994,11 +2994,11 @@ exports.Connection.prototype._bind_events = function(host, port, callback) {
 
     self._socket.on('close', function() {
 
-	    if (!self._isOpened || self._isDetach) {
-		    return;
-	    }
+        if (!self._isOpened || self._isDetach) {
+            return;
+        }
 
-	    self._isOpened = false;
+        self._isOpened = false;
 
         if (!self.db) {
             if (callback)
@@ -3007,7 +3007,7 @@ exports.Connection.prototype._bind_events = function(host, port, callback) {
         }
 
        self._retry_connection_id = setTimeout(function() {
-	        self._socket.removeAllListeners();
+            self._socket.removeAllListeners();
             self._socket = null;
 
             var ctx = new Connection(host, port, function(err) {
@@ -3674,7 +3674,7 @@ Connection.prototype.detach = function (callback) {
     msg.addInt(0); // Database Object ID
 
     self._queueEvent(function(err, ret) {
-    	clearTimeout(self._retry_connection_id);
+        clearTimeout(self._retry_connection_id);
         delete(self.dbhandle);
         if (callback)
             callback(err, ret);

--- a/test/config.js
+++ b/test/config.js
@@ -13,7 +13,8 @@ exports.default = {
     role: null,
     pageSize: 4096,
     timeout: 3000,
-    lowercase_keys: true
+    lowercase_keys: true,
+    retryConnectionInterval: 100
 };
 
 exports.currentDate = currentDate;

--- a/test/config.js
+++ b/test/config.js
@@ -8,7 +8,7 @@ exports.default = {
     database: path.join(process.env.FIREBIRD_DATA || testDir, dbName),
     host: '127.0.0.1',
     port: 3050,
-    user: 'sysdba',
+    user: 'SYSDBA',
     password: 'masterkey',
     role: null,
     pageSize: 4096,

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,8 @@ describe('Connection', function () {
         Firebird.attach(config, function (err, db) {
             assert.ok(!err, err);
 
-            db.connection._socket.end();
+            db.connection._socket.destroy();
+
             db.on('reconnect', function () {
                 db.detach();
                 done();


### PR DESCRIPTION
Hey - thanks for spending time working on this library, it's great!

This pull request aims to fix the following issues #195, #138.

The current solution does not work because we are resetting the socket and never reassign him. 
The next problem was with bounded event handlers to socket, they were firing infinitely. The `close` event was fired and an immediately new connection was created, again, again and again.

The proposed solution fixes mentioned issues and offer a possible setting of the reconnection interval. Tested locally by simulating connection drops (force killing Firebird server).

Thanks.