### PR TITLE
Fix attaching to database if database does not exists

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1302,7 +1302,9 @@ SQLParamBool.prototype.calcBlr = function(blr) {
  ***************************************/
 
 function isError(obj) {
-    return (obj instanceof Object && obj.status);
+    return Boolean(
+      obj != null && typeof obj === "object" && !Array.isArray(obj) && obj.status
+    );
 }
 
 function doCallback(obj, callback) {

--- a/test/index.js
+++ b/test/index.js
@@ -13,9 +13,7 @@ describe('Connection', function () {
     it('should attach or create database', function (done) {
         Firebird.attachOrCreate(config, function (err, db) {
             assert.ok(!err, err);
-
-            db.detach();
-            done();
+            db.detach(done);
         });
     });
 
@@ -26,8 +24,7 @@ describe('Connection', function () {
             db.connection._socket.destroy();
 
             db.on('reconnect', function () {
-                db.detach();
-                done();
+                db.detach(done);
             });
         });
     });
@@ -37,8 +34,7 @@ describe('Connection', function () {
         Firebird.create(testCreateConfig, function(err, db) {
             assert.ok(!err, err);
 
-            db.detach();
-            done();
+            db.detach(done);
         });
     });
 
@@ -59,8 +55,7 @@ describe('Auth plugin connection', function () {
         Firebird.attachOrCreate(Config.extends(config, { pluginName: Firebird.AUTH_PLUGIN_LEGACY }), function (err, db) {
             assert.ok(!err, 'Maybe firebird 3.0 Legacy_Auth plugin not enabled, message : ' + (err ? err.message : ''));
 
-            db.detach();
-            done();
+            db.detach(done);
         });
     });
 
@@ -69,8 +64,7 @@ describe('Auth plugin connection', function () {
         Firebird.attachOrCreate(Config.extends(config), function (err, db) {
             assert.ok(!err, err);
 
-            db.detach();
-            done();
+            db.detach(done);
         });
     });
 
@@ -91,8 +85,7 @@ describe('Auth plugin connection', function () {
             Firebird.attachOrCreate(Config.extends(config, { pluginName: Firebird.AUTH_PLUGIN_SRP }), function (err, db) {
                 assert.ok(!err, err);
 
-                db.detach();
-                done();
+                db.detach(done);
             });
         });
 
@@ -101,8 +94,7 @@ describe('Auth plugin connection', function () {
             Firebird.attachOrCreate(Config.extends(config, { pluginName: Firebird.AUTH_PLUGIN_SRP256 }), function (err, db) {
                 assert.ok(!err, err);
 
-                db.detach();
-                done();
+                db.detach(done);
             });
         });*/
     });

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,12 @@
-var Firebird = require('../lib');
-var { GDSCode } = require('../lib/gdscodes');
-var Config = require('./config');
+const Firebird = require('../lib');
+const { GDSCode } = require('../lib/gdscodes');
+const Config = require('./config');
 
-var assert = require('assert');
-var fs = require('fs');
-var path = require('path');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 
-var config = Config.default;
+const config = Config.default;
 
 describe('Connection', function () {
 
@@ -51,7 +51,7 @@ describe('Connection', function () {
 describe('Auth plugin connection', function () {
 
     // Must be test with firebird 2.5 or higher with Legacy_Auth enabled on server
-    it('should attach with lagacy plugin', function (done) {
+    it('should attach with legacy plugin', function (done) {
         Firebird.attachOrCreate(Config.extends(config, { pluginName: Firebird.AUTH_PLUGIN_LEGACY }), function (err, db) {
             assert.ok(!err, 'Maybe firebird 3.0 Legacy_Auth plugin not enabled, message : ' + (err ? err.message : ''));
 


### PR DESCRIPTION
Hey, I find out that `attachOrCreate` does not work properly – the `createDatabase` is never being called from `attachOrCreate` method. 

The reason is that the error from the database is detected, but there is a pitfall in `isError` method, which mark input as error only and only if it is **plain object** and has status property on it, but in this case, the error message with status is attached to object, which is an instance of Database.

This pitfall was not detected in tests, because of not awaiting the detach method - so it never gets propagated.

Thanks.