### PR TITLE
Add definitions to transaction isolation modes

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -16,9 +16,16 @@ declare module 'node-firebird' {
     export const WIRE_CRYPT_ENABLE: number;
     export const WIRE_CRYPT_DISABLE: number;
 
+    /** A transaction sees changes done by uncommitted transactions. */
     export const ISOLATION_READ_UNCOMMITTED: number[];
+    /** A transaction sees only data committed before the statement has been executed. */
     export const ISOLATION_READ_COMMITED: number[];
+    /** A transaction sees during its lifetime only data committed before the transaction has been started. */
     export const ISOLATION_REPEATABLE_READ: number[];
+    /**
+     * This is the strictest isolation level, which enforces transaction serialization.
+     * Data accessed in the context of a serializable transaction cannot be accessed by any other transaction.
+     */
     export const ISOLATION_SERIALIZABLE: number[];
     export const ISOLATION_READ_COMMITED_READ_ONLY: number[];
 


### PR DESCRIPTION
These comments allow VSCode to show a definition for each transaction type when hovering them:

![Transaction definition on tooltip](https://user-images.githubusercontent.com/26308880/131260913-c274f2d8-f9d8-4124-8c36-254d6119a9d3.png)

I copied the definition from the [official docs](https://www.firebirdsql.org/pdfmanual/html/isql-transactions.html), but it doesn't have the _read-only_ definition. I imagine it could be something like:

> A transaction sees only data committed before the statement has been executed and has no write permission.

But, as I'm not sure about this definition, I didn't create a comment for it. What do you think?

---

Also, I'd like to mention that `ISOLATION_READ_COMMITED` has a typo, it should be `ISOLATION_READ_COMMITTED`. Changing it would break the existing code, so I didn't change it in this PR.