### PR TITLE
Added configurable character set for connections.

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -51,6 +51,37 @@ declare module 'node-firebird' {
         rollbackRetaining(callback?: SimpleCallback): void;
     }
 
+    export type SupportedCharacterSet = |
+        'NONE' |
+        'CP943C' |
+        'DOS737' |
+        'DOS775' |
+        'DOS858' |
+        'DOS862' |
+        'DOS864' |
+        'DOS866' |
+        'DOS869' |
+        'GB18030' |
+        'GBK' |
+        'ISO8859_2' |
+        'ISO8859_3' |
+        'ISO8859_4' |
+        'ISO8859_5' |
+        'ISO8859_6' |
+        'ISO8859_7' |
+        'ISO8859_8' |
+        'ISO8859_9' |
+        'ISO8859_13' |
+        'KOI8R' |
+        'KOI8U' |
+        'TIS620' |
+        'UTF8' |
+        'WIN1255' |
+        'WIN1256' |
+        'WIN1257' |
+        'WIN1258' |
+        'WIN_1258';
+
     export interface Options {
         host?: string;
         port?: number;
@@ -61,6 +92,7 @@ declare module 'node-firebird' {
         role?: string;
         pageSize?: number;
         retryConnectionInterval?: number;
+        encoding?: SupportedCharacterSet;
     }
 
     export interface SvcMgrOptions extends Options {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3605,7 +3605,7 @@ Connection.prototype.attach = function (options, callback, db) {
     blr.pos = 0;
 
     blr.addByte(isc_dpb_version1);
-    blr.addString(isc_dpb_lc_ctype, 'UTF8', DEFAULT_ENCODING);
+    blr.addString(isc_dpb_lc_ctype, options.encoding || 'UTF8', DEFAULT_ENCODING);
     blr.addString(isc_dpb_user_name, user, DEFAULT_ENCODING);
 	if (options.password && !this.accept.authData) {
 		if (this.accept.protocolVersion < PROTOCOL_VERSION13) {


### PR DESCRIPTION
Resolves #271 by making the character set (`isc_dpb_lc_ctype`) configurable on a connection. Default is still `UTF8` so this is not a breaking change.