### PR TITLE
feat(blob): add support value text for blob subtype 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ options.role = null;            // default
 options.pageSize = 4096;        // default when creating database
 options.pageSize = 4096;        // default when creating database
 options.retryConnectionInterval = 1000; // reconnect interval in case of connection drop
+options.blobAsText = false // set to true to get blob as text, only affects blob subtype 1
 ```
 
 ### Classic

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ options.role = null;            // default
 options.pageSize = 4096;        // default when creating database
 options.pageSize = 4096;        // default when creating database
 options.retryConnectionInterval = 1000; // reconnect interval in case of connection drop
-options.blobAsText = false // set to true to get blob as text, only affects blob subtype 1
+options.blobAsText = false; // set to true to get blob as text, only affects blob subtype 1
 ```
 
 ### Classic

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -93,6 +93,7 @@ declare module 'node-firebird' {
         pageSize?: number;
         retryConnectionInterval?: number;
         encoding?: SupportedCharacterSet;
+        blobAsText?: boolean; // only affects for blob subtype 1
     }
 
     export interface SvcMgrOptions extends Options {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3214,7 +3214,7 @@ function decodeResponse(data, callback, cnx, lowercase_keys, cb) {
                                 let key = custom.asObject ? data.fcols[data.fcolumn] : data.fcolumn;
                                 let value = item.decode(data, lowerV13);
                                 if (item.type === SQL_BLOB && value !== null) {
-                                    if (item.subType === isc_blob_text) {
+                                    if (item.subType === isc_blob_text && cnx.options.blobAsText) {
                                         value = fetch_blob_async_transaction(statement, value, key, data);
                                         arrBlob.push(value);
                                     } else {
@@ -3253,7 +3253,7 @@ function decodeResponse(data, callback, cnx, lowercase_keys, cb) {
                                 var key = custom.asObject ? data.fcols[data.fcolumn] : data.fcolumn;
                                 var value = item.decode(data, lowerV13);
                                 if (item.type === SQL_BLOB && value !== null) {
-                                    if (item.subType === isc_blob_text) {
+                                    if (item.subType === isc_blob_text && cnx.options.blobAsText) {
                                         value = fetch_blob_async_transaction(statement, value, key, data);
                                         arrBlob.push(value);
                                     } else {
@@ -3272,8 +3272,8 @@ function decodeResponse(data, callback, cnx, lowercase_keys, cb) {
 
                     data.fcolumn = 0;
                     // ToDo: emit "row" with blob subtype string decoded
-                    // use: data.frow['fieldBlob'](transaction?).then(({ v }) => console.log(v))
-                    // arg: "transaction" is optional
+                    // use: data.frow['fieldBlob'](transaction?).then(({ value }) => console.log(value))
+                    // arg "transaction" is optional
                     statement.connection.db.emit('row', data.frow, statement.nbrowsfetched, custom.asObject);
                     data.frows.push(data.frow);
                     data.frow = custom.asObject ? {} : new Array(output.length);
@@ -3309,7 +3309,7 @@ function decodeResponse(data, callback, cnx, lowercase_keys, cb) {
                 }
 
                 // ToDo: emit "result" with blob subtype string decoded
-                statement.connection.db.emit('result', data.frows);
+                statement.connection.db.emit('result', data.frows, arrBlob);
                 return cb(null, {data: data.frows, fetched: Boolean(!isOpFetch || data.fstatus === 100), arrBlob});
             case op_accept:
             case op_cond_accept:
@@ -4430,7 +4430,11 @@ Connection.prototype.sendExecute = function (op, statement, transaction, callbac
 }
 
 function fetch_blob_async_transaction(statement, id, name, data) {
-    const infoValue = { r: data.frows.length, c: name, v: '' };
+    const infoValue = {
+        row: data.frows.length,
+        column: name,
+        value: ''
+    };
 
     return (transactionArg) => {
         const singleTransaction = transactionArg === undefined;
@@ -4474,7 +4478,7 @@ function fetch_blob_async_transaction(statement, id, name, data) {
                             if (ret.buffer) {
                                 const blr = new BlrReader(ret.buffer);
                                 const data = blr.readSegment();
-                                infoValue.v += data.toString(DEFAULT_ENCODING);
+                                infoValue.value += data.toString(DEFAULT_ENCODING);
                             }
     
                             if (ret.handle !== 2) {
@@ -4612,7 +4616,7 @@ Connection.prototype.fetchAll = function (statement, transaction, callback) {
             Promise.all(arrPromise).then((arrBlob) => {
                 for (let i = 0; i < arrBlob.length; i++) {
                     const blob = arrBlob[i];
-                    ret.data[blob.r][blob.c] = blob.v;
+                    ret.data[blob.row][blob.column] = blob.value;
                 }
 
                 for (let i = 0; i < ret.data.length; i++) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3200,6 +3200,8 @@ function decodeResponse(data, callback, cnx, lowercase_keys, cb) {
                     }
                 }
 
+                const arrBlob = [];
+
                 while (data.fcount && (data.fstatus !== 100)) {
                     var lowerV13 = statement.connection.accept.protocolVersion < PROTOCOL_VERSION13;
 
@@ -3211,8 +3213,13 @@ function decodeResponse(data, callback, cnx, lowercase_keys, cb) {
                                 _xdrpos = data.pos;
                                 let key = custom.asObject ? data.fcols[data.fcolumn] : data.fcolumn;
                                 let value = item.decode(data, lowerV13);
-                                if (item.type === SQL_BLOB) {
-                                    value = fetch_blob_async(statement, value, key);
+                                if (item.type === SQL_BLOB && value !== null) {
+                                    if (item.subType === isc_blob_text) {
+                                        value = fetch_blob_async_transaction(statement, value, key, data);
+                                        arrBlob.push(value);
+                                    } else {
+                                        value = fetch_blob_async(statement, value, key);
+                                    }
                                 }
                                 data.frow[key] = value;
                             } catch (e) {
@@ -3245,8 +3252,13 @@ function decodeResponse(data, callback, cnx, lowercase_keys, cb) {
                                 _xdrpos = data.pos;
                                 var key = custom.asObject ? data.fcols[data.fcolumn] : data.fcolumn;
                                 var value = item.decode(data, lowerV13);
-                                if (item.type === SQL_BLOB) {
-                                    value = fetch_blob_async(statement, value, key);
+                                if (item.type === SQL_BLOB && value !== null) {
+                                    if (item.subType === isc_blob_text) {
+                                        value = fetch_blob_async_transaction(statement, value, key, data);
+                                        arrBlob.push(value);
+                                    } else {
+                                        value = fetch_blob_async(statement, value, key);
+                                    }
                                 }
                                 data.frow[key] = value;
                             } catch (e) {
@@ -3259,6 +3271,9 @@ function decodeResponse(data, callback, cnx, lowercase_keys, cb) {
                     }
 
                     data.fcolumn = 0;
+                    // ToDo: emit "row" with blob subtype string decoded
+                    // use: data.frow['fieldBlob'](transaction?).then(({ v }) => console.log(v))
+                    // arg: "transaction" is optional
                     statement.connection.db.emit('row', data.frow, statement.nbrowsfetched, custom.asObject);
                     data.frows.push(data.frow);
                     data.frow = custom.asObject ? {} : new Array(output.length);
@@ -3293,8 +3308,9 @@ function decodeResponse(data, callback, cnx, lowercase_keys, cb) {
                     statement.nbrowsfetched++;
                 }
 
+                // ToDo: emit "result" with blob subtype string decoded
                 statement.connection.db.emit('result', data.frows);
-                return cb(null, {data: data.frows, fetched: Boolean(!isOpFetch || data.fstatus === 100)});
+                return cb(null, {data: data.frows, fetched: Boolean(!isOpFetch || data.fstatus === 100), arrBlob});
             case op_accept:
             case op_cond_accept:
             case op_accept_data:
@@ -4413,10 +4429,82 @@ Connection.prototype.sendExecute = function (op, statement, transaction, callbac
 	this._queueEvent(callback);
 }
 
-function fetch_blob_async(statement, id, name) {
+function fetch_blob_async_transaction(statement, id, name, data) {
+    const infoValue = { r: data.frows.length, c: name, v: '' };
 
-    if (!id)
-        return null;
+    return (transactionArg) => {
+        const singleTransaction = transactionArg === undefined;
+
+        let promiseTransaction;
+        if (singleTransaction) {
+            promiseTransaction = new Promise((resolve, reject) => {
+                statement.connection.startTransaction(ISOLATION_READ_UNCOMMITTED, (err, transaction) => {
+                    if (err) {
+                        return reject(err);
+                    }
+                    resolve(transaction);
+                });
+            });
+        } else {
+            promiseTransaction = Promise.resolve(transactionArg);
+        }
+
+        return promiseTransaction.then((transaction) => {
+            return new Promise((resolve, reject) => {
+                statement.connection._pending.push('openBlob');
+                statement.connection.openBlob(id, transaction, (err, blob) => {
+    
+                    if (err) {
+                        reject(err);
+                        return;
+                    }
+    
+                    const read = () => {
+                        statement.connection.getSegment(blob, (err, ret) => {
+    
+                            if (err) {
+                                if (singleTransaction) {
+                                    transaction.rollback(() => reject(err));
+                                } else {
+                                    reject(err);
+                                }
+                                return;
+                            }
+    
+                            if (ret.buffer) {
+                                const blr = new BlrReader(ret.buffer);
+                                const data = blr.readSegment();
+                                infoValue.v += data.toString(DEFAULT_ENCODING);
+                            }
+    
+                            if (ret.handle !== 2) {
+                                read();
+                                return;
+                            }
+    
+                            statement.connection.closeBlob(blob);
+                            if (singleTransaction) {
+                                transaction.commit((err) => {
+                                    if (err) {
+                                        reject(err);
+                                    } else {
+                                        resolve(infoValue);
+                                    }
+                                });
+                            } else {
+                                resolve(infoValue);
+                            }
+                        });
+                    };
+    
+                    read();
+                });
+            });
+        });
+    };
+}
+
+function fetch_blob_async(statement, id, name) {
 
     return function(callback) {
         // callback(err, buffer, name);
@@ -4514,24 +4602,33 @@ Connection.prototype.fetch = function(statement, transaction, count, callback) {
 };
 
 Connection.prototype.fetchAll = function (statement, transaction, callback) {
-	var self = this, data = [];
-	var loop = function (err, ret) {
+	const self = this, data = [];
+	const loop = (err, ret) => {
 		if (err) {
 			return callback(err);
 		} else if (ret && ret.data && ret.data.length) {
-			for (var i = 0; i < ret.data.length; i++) {
-				var pos = data.push(ret.data[i]);
-				if (statement.custom && statement.custom.asStream && statement.custom.on) {
-					statement.custom.on(ret.data[i], pos - 1);
-				}
-				if (i === ret.data.length - 1) {
-					if (ret.fetched) {
-						return callback(undefined, data);
-					} else {
-						self.fetch(statement, transaction, DEFAULT_FETCHSIZE, loop);
-					}
-				}
-			}
+            const arrPromise = (ret.arrBlob || []).map(value => value(transaction));
+
+            Promise.all(arrPromise).then((arrBlob) => {
+                for (let i = 0; i < arrBlob.length; i++) {
+                    const blob = arrBlob[i];
+                    ret.data[blob.r][blob.c] = blob.v;
+                }
+
+                for (let i = 0; i < ret.data.length; i++) {
+                    const pos = data.push(ret.data[i]);
+                    if (statement.custom && statement.custom.asStream && statement.custom.on) {
+                        statement.custom.on(ret.data[i], pos - 1);
+                    }
+                    if (i === ret.data.length - 1) {
+                        if (ret.fetched) {
+                            return callback(undefined, data);
+                        } else {
+                            self.fetch(statement, transaction, DEFAULT_FETCHSIZE, loop);
+                        }
+                    }
+                }
+            }).catch(callback);
 		} else if (ret.fetched) {
 			callback(undefined, data);
 		} else {


### PR DESCRIPTION
1. I believe that blob fields with subtype text (1) should not return a callback with an eventemitter as a parameter, this should have the same behavior as varchar fields.
2. To get the value of the blob fields, a transaction is created for each value, so I have created a function that allows sending the only transaction as a parameter and if not, it creates it for each read. Use: ``const value = await row['fieldBlob'](transaction?);``. We should have this possibility for the other subtypes

In refence to:
#206 #241 

*** UPDATE ***
The "blobAsText" option was added, only affects blob subtype 1

```js
const options = {};

options.host = '127.0.0.1';
options.port = 3050;
options.database = 'database.fdb';
options.user = 'SYSDBA';
options.password = 'masterkey';
options.lowercase_keys = false; // set to true to lowercase keys
options.role = null;            // default
options.pageSize = 4096;        // default when creating database
options.pageSize = 4096;        // default when creating database
options.retryConnectionInterval = 1000; // reconnect interval in case of connection drop
options.blobAsText = false; // set to true to get blob as text, only affects blob subtype 1
```

@mariuz  @mapopa 