### PR TITLE
Fix blobAsText exception

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4661,7 +4661,7 @@ Connection.prototype.fetchAll = function (statement, transaction, callback) {
             Promise.all(arrPromise).then((arrBlob) => {
                 for (let i = 0; i < arrBlob.length; i++) {
                     const blob = arrBlob[i];
-                    ret.data[blob.row][blob.column] = blob.value;
+                    ret.data[i][blob.column] = blob.value;
                 }
 
                 const lastIndex = ret.data.length - 1;


### PR DESCRIPTION
Hi,

i was working with node-firebird@1.1.1 with the `blobAsText: true` option and encountered the following problem:

![image](https://user-images.githubusercontent.com/31471771/200112048-d1374b8c-2e99-44b1-bf04-f612b94a047d.png)

The problem is caused by the fact that `blob.row` has as its value an object and not a number.
Using the value of `i` to iterate `ret.data` in my test cases solved the problem.

P.S. Thank you for the work done with this module!