### PR TITLE
Fix fetch error test 

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -475,7 +475,7 @@ describe('Database', function() {
 
                 db.query('select RET from TEST_FETCH_FAIL', (err, d) => {
                     assert.ok(err, err);
-                    assert.ok(err.message.indexOf('arithmetic exception, numeric overflow, or string truncation, Integer divide by zero.') === 0);
+                    assert.ok(err.message.match(/arithmetic exception, numeric overflow, or string truncation, Integer divide by zero./gi));
 
                     done();
                 });


### PR DESCRIPTION
Fix error message comparaison. 
Test is ok, but error string in tests do not match case.
