### PR TITLE
feat: Register events and handle event changes

### DIFF
--- a/lib/wire/eventConnection.js
+++ b/lib/wire/eventConnection.js
@@ -76,7 +76,7 @@ EventConnection.prototype._bind_events = function (host, port, callback) {
                             eventcount = buf.readInt32LE(pos);
                             tmp_event[eventname] = eventcount;
                             pos += 4;
-                            if (prevcount !== eventcount)
+                            if (prevcount !== 0 && prevcount !== eventcount)
                                 lst_event.push({ name: eventname, count: eventcount });
                         }
                         xdr.readInt64(); // ignore AST INFO

--- a/lib/wire/fbEventManager.js
+++ b/lib/wire/fbEventManager.js
@@ -39,6 +39,11 @@ FbEventManager.prototype._createEventLoop = function (callback) {
             return;
         }
 
+        if (ret.events?.length == 0) {
+            // events has been registred
+            self.emit('events_registered', self.events);
+        }
+
         ret.events.forEach(function (event) {
             self.emit('post_event', event.name, event.count)
         })
@@ -57,7 +62,7 @@ FbEventManager.prototype._changeEvent = function (callback) {
             doError(err, callback);
             return;
         }
-        
+
         self.db.connection.queEvents(self.events, self.eventid, callback);
     })
 }


### PR DESCRIPTION
This commit adds a new event for now when events are registered.

It also includes tests for event registration and receiving events. The changes ensure that events are properly registered and that event counts are updated correctly.