### PR TITLE
Correction of logic

### DIFF
--- a/lib/wire/xsqlvar.js
+++ b/lib/wire/xsqlvar.js
@@ -22,9 +22,6 @@ SQLVarText.prototype.decode = function(data, lowerV13) {
     if (this.subType > 1) {
         // ToDo: with column charset
         ret = data.readText(this.length, Const.DEFAULT_ENCODING);
-    } else if (this.subType === 0) {
-        // without charset definition
-        ret = data.readText(this.length, Const.DEFAULT_ENCODING);
     } else {
         ret = data.readBuffer(this.length);
     }
@@ -56,10 +53,7 @@ SQLVarString.prototype.decode = function(data, lowerV13) {
     if (this.subType > 1) {
         // ToDo: with column charset
         ret = data.readString(Const.DEFAULT_ENCODING);
-    } else if (this.subType === 0) {
-        // without charset definition
-        ret = data.readString(Const.DEFAULT_ENCODING);
-    } else {
+    }  else {
         ret = data.readBuffer();
     }
 


### PR DESCRIPTION
This behavior leads to the fact that the encoding breaks when a database other than utf8 is installed on the database itself and there is no possibility of working with a raw buffer in order to fix it