### PR TITLE
Fixed crash on missing buffer

### DIFF
--- a/lib/wire/service.js
+++ b/lib/wire/service.js
@@ -135,102 +135,110 @@ class ServiceManager extends Events.EventEmitter {
     }
 
     _processquery(buffer, callback) {
-        //console.log(buffer);
-        var br = new BlrReader(buffer);
-        var tinfo = br.readByteCode();
-        var res = {};
-        res.result = 0;
-        for (; tinfo !== Const.isc_info_end; tinfo = br.readByteCode()) {
-            switch (tinfo) {
-                case Const.isc_info_svc_server_version:
-                case Const.isc_info_svc_implementation:
-                case Const.isc_info_svc_user_dbpath:
-                case Const.isc_info_svc_get_env:
-                case Const.isc_info_svc_get_env_lock:
-                case Const.isc_info_svc_get_env_msg:
-                    res[this._infosmapping[tinfo]] = br.readString();
-                    break;
-                case Const.isc_info_svc_version:
-                    res[this._infosmapping[tinfo]] = br.readInt32();
-                    break;
-                case Const.isc_info_svc_svr_db_info:
-                    this._processdbinfo(br, res);
-                    break;
-                case Const.isc_info_svc_limbo_trans:
-                    // not implemented
-                    for (; tinfo !== isc_info_flag_end; tinfo = br.readByteCode())
-                        break;
-                case Const.isc_info_svc_get_users:
-                    br.pos += 2
-                    res[this._infosmapping[tinfo]] = [];
-                    break;
-                case Const.isc_spb_sec_username:
-                    var tuser = res[this._infosmapping[68]];
-                    tuser.push({});
-                    tuser[tuser.length - 1].username = br.readString();
-                    break;
-                case Const.isc_spb_sec_firstname:
-                    var tuser = res[this._infosmapping[68]];
-                    var user = tuser[tuser.length-1];
-                    user.firstname = br.readString();
-                    break;
-                case Const.isc_spb_sec_middlename:
-                    var tuser = res[this._infosmapping[68]];
-                    var user = tuser[tuser.length-1];
-                    user.middlename = br.readString();
-                    break;
-                case Const.isc_spb_sec_lastname:
-                    var tuser = res[this._infosmapping[68]];
-                    var user = tuser[tuser.length-1];
-                    user.lastname = br.readString();
-                    break;
-                case Const.isc_spb_sec_groupid:
-                    var tuser = res[this._infosmapping[68]];
-                    var user = tuser[tuser.length-1];
-                    user.groupid = br.readInt32();
-                    break;
-                case Const.isc_spb_sec_userid:
-                    var tuser = res[this._infosmapping[68]];
-                    var user = tuser[tuser.length-1];
-                    user.userid = br.readInt32();
-    
-                    break;
-                case Const.isc_spb_sec_admin:
-                    var tuser = res[this._infosmapping[68]];
-                    var user = tuser[tuser.length-1];
-                    user.admin = br.readInt32();
-                    break;
-    
-                case Const.isc_info_svc_line:
-                    res.line = br.readString();
-                    break;
-    
-                case Const.isc_info_svc_to_eof:
-                    res.line = br.readString();
-                    break;
-    
-                case Const.isc_info_truncated:
-                    res.result = 1; // too much data for the result buffer increase size of it (buffersize parameter))
-                    break;
-    
-                case Const.isc_info_data_not_ready:
-                    res.result = 2;
-                    break;
-    
-                case Const.isc_info_svc_timeout:
-                    res.result = 3;
-                    break;
-    
-                case Const.isc_info_svc_stdin:
-    
-                    break;
-    
-                case Const.isc_info_svc_capabilities:
-                    this._processcapabilities(br, res);
-                    break;
-            }
+        if (!Buffer.isBuffer(buffer)) {
+            doError(new Error('Malformed service-manager response: missing BLR buffer'), callback);
+            return;
         }
-        callback(null, res);
+
+        try {
+            var br = new BlrReader(buffer);
+            var tinfo = br.readByteCode();
+            var res = {};
+            res.result = 0;
+            for (; tinfo !== Const.isc_info_end; tinfo = br.readByteCode()) {
+                switch (tinfo) {
+                    case Const.isc_info_svc_server_version:
+                    case Const.isc_info_svc_implementation:
+                    case Const.isc_info_svc_user_dbpath:
+                    case Const.isc_info_svc_get_env:
+                    case Const.isc_info_svc_get_env_lock:
+                    case Const.isc_info_svc_get_env_msg:
+                        res[this._infosmapping[tinfo]] = br.readString();
+                        break;
+                    case Const.isc_info_svc_version:
+                        res[this._infosmapping[tinfo]] = br.readInt32();
+                        break;
+                    case Const.isc_info_svc_svr_db_info:
+                        this._processdbinfo(br, res);
+                        break;
+                    case Const.isc_info_svc_limbo_trans:
+                        // not implemented
+                        for (; tinfo !== isc_info_flag_end; tinfo = br.readByteCode())
+                            break;
+                    case Const.isc_info_svc_get_users:
+                        br.pos += 2
+                        res[this._infosmapping[tinfo]] = [];
+                        break;
+                    case Const.isc_spb_sec_username:
+                        var tuser = res[this._infosmapping[68]];
+                        tuser.push({});
+                        tuser[tuser.length - 1].username = br.readString();
+                        break;
+                    case Const.isc_spb_sec_firstname:
+                        var tuser = res[this._infosmapping[68]];
+                        var user = tuser[tuser.length-1];
+                        user.firstname = br.readString();
+                        break;
+                    case Const.isc_spb_sec_middlename:
+                        var tuser = res[this._infosmapping[68]];
+                        var user = tuser[tuser.length-1];
+                        user.middlename = br.readString();
+                        break;
+                    case Const.isc_spb_sec_lastname:
+                        var tuser = res[this._infosmapping[68]];
+                        var user = tuser[tuser.length-1];
+                        user.lastname = br.readString();
+                        break;
+                    case Const.isc_spb_sec_groupid:
+                        var tuser = res[this._infosmapping[68]];
+                        var user = tuser[tuser.length-1];
+                        user.groupid = br.readInt32();
+                        break;
+                    case Const.isc_spb_sec_userid:
+                        var tuser = res[this._infosmapping[68]];
+                        var user = tuser[tuser.length-1];
+                        user.userid = br.readInt32();
+        
+                        break;
+                    case Const.isc_spb_sec_admin:
+                        var tuser = res[this._infosmapping[68]];
+                        var user = tuser[tuser.length-1];
+                        user.admin = br.readInt32();
+                        break;
+        
+                    case Const.isc_info_svc_line:
+                        res.line = br.readString();
+                        break;
+        
+                    case Const.isc_info_svc_to_eof:
+                        res.line = br.readString();
+                        break;
+        
+                    case Const.isc_info_truncated:
+                        res.result = 1; // too much data for the result buffer increase size of it (buffersize parameter))
+                        break;
+        
+                    case Const.isc_info_data_not_ready:
+                        res.result = 2;
+                        break;
+        
+                    case Const.isc_info_svc_timeout:
+                        res.result = 3;
+                        break;
+        
+                    case Const.isc_info_svc_stdin:
+        
+                        break;
+        
+                    case Const.isc_info_svc_capabilities:
+                        this._processcapabilities(br, res);
+                        break;
+                }
+            }
+            callback(null, res);
+        } catch (err) {
+            doError(new Error('Malformed service-manager response: ' + err.message), callback);
+        }
     }
 
     detach(callback, force) {

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var Const = require('../lib/wire/const');
 var Firebird = require('../lib');
+var ServiceManager = require('../lib/wire/service');
 
 describe('Test Firebird 3.0 and 4.0 protocol support', function () {
     it('should define protocol versions 14, 15, 16, and 17', function () {
@@ -69,5 +70,27 @@ describe('Test Firebird 3.0 and 4.0 protocol support', function () {
     it('should define INT128 data type constants', function () {
         assert.strictEqual(Const.SQL_INT128, 32752, 'SQL_INT128 should be 32752');
         assert.strictEqual(Const.blr_int128, 26, 'blr_int128 should be 26');
+    });
+
+    it('should return a callback error for missing service query buffer', async function () {
+        var svc = new ServiceManager({});
+        await new Promise(function (resolve) {
+            svc._processquery(undefined, function (err) {
+                assert.ok(err instanceof Error);
+                assert.match(err.message, /malformed service-manager response/i);
+                resolve();
+            });
+        });
+    });
+
+    it('should return a callback error for truncated service query buffer', async function () {
+        var svc = new ServiceManager({});
+        await new Promise(function (resolve) {
+            svc._processquery(Buffer.from([Const.isc_info_svc_server_version]), function (err) {
+                assert.ok(err instanceof Error);
+                assert.match(err.message, /malformed service-manager response/i);
+                resolve();
+            });
+        });
     });
 });


### PR DESCRIPTION
Hardened ServiceManager._processquery() in lib/wire/service.js:
- Validates BLR buffer presence before parsing.
- Wraps BLR parsing in try/catch and returns callback errors instead of throwing TypeError crashes.
- Normalized error message format: Malformed service-manager response.

Added focused regression tests in test/protocol.js:
- Missing query buffer case.
- Truncated query buffer case.