### PR TITLE
Issue #411 - upgrade regressions

### DIFF
--- a/lib/srp.js
+++ b/lib/srp.js
@@ -24,7 +24,11 @@ const PRIME = {
  * @param a BigInt Client private key.
  * @returns {{private: BigInt, public: BigInt}}
  */
-exports.clientSeed = function(a = toBigInt(crypto.randomBytes(SRP_KEY_SIZE))) {
+exports.clientSeed = function(a = toBigInt(crypto.randomBytes(SRP_KEY_SIZE)) % PRIME.N) {
+    // a must be < N: clientSession() reduces the exponent (a + ux) mod N to
+    // match the Firebird engine, but A = g^a is computed from the UNREDUCED a.
+    // If the 1024-bit random a is >= N (~10% chance), the proof no longer
+    // matches the server's session key and authentication fails sporadically.
     var A = modPow(PRIME.g, a, PRIME.N);
 
     dump('a', a);

--- a/lib/wire/socket.js
+++ b/lib/wire/socket.js
@@ -98,10 +98,16 @@ class Socket {
      * Compress and/or encrypt data before sending to socket.
      */
     write(data, defer = false) {
-        if (defer) {
-            this.buffer = Buffer.from(data);
-            return;
-        }
+         if (defer) {
+            // multiple deferred packets (e.g. op_close_blob followed by
+            // op_free_statement) must all be kept until the next flush -
+            // overwriting the buffer would silently drop packets and
+            // desynchronize the request/response queue
+            this.buffer = this.buffer
+                ? Buffer.concat([this.buffer, Buffer.from(data)])
+                : Buffer.from(data);
+             return;
+         }
 
         if (!defer && this.buffer) {
             data = Buffer.concat([this.buffer, data]);


### PR DESCRIPTION
Be prepared for AI-Writeup of the errors:

# Bug 1: Consecutive deferred packets overwrite each other in Socket.write() — connection hangs permanently after any SELECT returning a non-null BLOB
Affected: node-firebird 2.3.2 (regression vs. 1.1.9), tested against Firebird 5.0.3, protocol 16/17, Node.js 24

## Summary
lib/wire/socket.js buffers deferred packets like this:


write(data, defer = false) {
    if (defer) {
        this.buffer = Buffer.from(data);   // <-- overwrites any previously deferred packet
        return;
    }
    ...
}
When two deferred packets are written back-to-back before a flush, the first one is silently dropped. This happens on every SELECT that returns a non-null BLOB column (blobAsText: true):

After the last op_get_segment, the blob fetch path calls closeBlob(blob) without a callback → _queueEvent(undefined, defer=true) → the op_close_blob packet is stored in socket.buffer, and an entry is pushed onto _queue (the response accounting queue).
Immediately afterwards, transaction.execute() calls statement.release() → dropStatement() → also deferred → socket.buffer = Buffer.from(op_free_statement) — the op_close_blob packet is overwritten and never sent.
### Consequence: request/response queue desync
The next query flushes the buffer. The server receives [op_free_statement, op_allocate_statement, op_prepare_statement] and sends 3 responses — but the client's _queue is expecting 4 (close_blob, free, and the allocate+prepare callback with lazy_count = 2). Every response is now matched to the wrong callback:

free-statement response → consumed by the close_blob queue entry
allocate response → consumed by the free queue entry
prepare response → parsed by the allocate+prepare callback, which expects two responses (lazy_count = 2), reads past the end of the buffer, hits a RangeError, and treats it as an incomplete TCP packet — saving the bytes and waiting for more data that will never arrive.
The connection is dead from that point on; every subsequent operation hangs forever with no error callback. With FIREBIRD_DEBUG=1 the desync is clearly visible: 3 responses arrive against queue=3 entries, the last decode ends in incomplete packet: saved N bytes and then silence.

## Reproduction

fb.attach(options, (err, db) => {
    db.transaction(fb.ISOLATION_READ_COMMITTED, (err, tr) => {
        tr.query('SELECT MY_BLOB_COLUMN FROM SOME_TABLE WHERE MY_BLOB_COLUMN IS NOT NULL', [], (err, r1) => {
            // works fine
            tr.query('SELECT 1 FROM RDB$DATABASE', [], (err, r2) => {
                // never reached — hangs forever
            });
        });
    });
});
Requires blobAsText: true and at least one non-null BLOB in the result. Without the BLOB column, the same sequence works (only one deferred packet in flight, so the overwrite never triggers).

## Fix
Accumulate deferred packets instead of overwriting:


write(data, defer = false) {
    if (defer) {
        this.buffer = this.buffer
            ? Buffer.concat([this.buffer, Buffer.from(data)])
            : Buffer.from(data);
        return;
    }
    ...
}
Verified with a stress test (10 rounds of blob-query + plain query + commitRetaining on one connection, 20 process runs): 100% hang before the fix, 0 failures after.

# Bug 2: SRP authentication fails sporadically (~10% of attaches) when the random private key a >= N — attach() then hangs with no error
Affected: node-firebird 2.3.2, Firebird 5.0.3, Srp256/Srp

## Summary
lib/srp.js generates the client private key as 128 raw random bytes, unreduced:


exports.clientSeed = function(a = toBigInt(crypto.randomBytes(SRP_KEY_SIZE))) {
    var A = modPow(PRIME.g, a, PRIME.N);   // A computed from the UNREDUCED a
    ...
}
but clientSession() later reduces the exponent mod N (the comment says this matches the Firebird engine):


var aux = (a + ux) % PRIME.N;
var sessionSecret = modPow(diff, aux, PRIME.N);
These two are only consistent while a + ux < N. a is uniform in [0, 2^1024) and N ≈ 0.9 · 2^1024 (top byte 0xE6), so with probability ≈ 10% per attach we get a >= N, the reduction actually fires, and the client computes (g^b)^((a+ux) mod N) while the server computes (A · v^u)^b = g^(b·(a+ux)). Since exponent arithmetic for g is only valid mod ord(g) (which divides N−1, not N), the session keys disagree and the client proof M is wrong.

## Consequence
The server rejects the Srp256 proof and falls back to the next plugin via op_cont_auth (plugin: Srp). The driver doesn't handle this mid-attach (Unhandled server op_cont_auth for plugin: Srp) and attach() hangs forever — no error callback, no timeout. To the application this looks like random, unreproducible connection failures: retrying usually succeeds because the next random key is fine. In our connection pool (50 connections at startup) we consistently lost ~10–15% of attaches to this.

## Proof that this is the root cause
Forcing the private key deterministically makes the failure binary:


const srp = require('node-firebird/lib/srp.js');
const orig = srp.clientSeed;
srp.clientSeed = () => orig(N + (1n << 512n));  // a > N → attach hangs, 100% of the time
srp.clientSeed = () => orig(N - (1n << 512n));  // a < N → attach succeeds, 100% of the time

## Fix
Reduce the key once at generation, so A and the proof are derived from the same value:


exports.clientSeed = function(a = toBigInt(crypto.randomBytes(SRP_KEY_SIZE)) % PRIME.N) {
After this, (a + ux) % N never actually reduces in practice (ux < 2^320, negligible vs. N), so the existing "match the engine" reduction becomes a no-op and both sides agree. Verified with 20 consecutive runs of a multi-attach stress test: 5/15 attach hangs before, 0/20 after.

A secondary suggestion independent of the fix: an unhandled op_cont_auth during attach should surface as an error callback rather than hanging silently — it would have made both this bug and Bug 1 far easier to find in production.
