### PR TITLE
fix: respect connection encoding when decoding text results

### DIFF
--- a/lib/wire/xsqlvar.js
+++ b/lib/wire/xsqlvar.js
@@ -13,6 +13,16 @@ const
     TimeCoeff = 86400000,
     MsPerMinute = 60000;
 
+const FirebirdToNodeEncoding = Object.freeze({
+    UTF8: 'utf8',
+    UNICODE_FSS: 'utf8',
+    WIN1252: 'latin1',
+    ISO8859_1: 'latin1',
+    LATIN1: 'latin1',
+    ASCII: 'ascii',
+    NONE: 'latin1'
+});
+
 const FirebirdCharsetWidths = {
     'UTF8': 4,
     'UNICODE_FSS': 3,
@@ -26,14 +36,20 @@ function getFirebirdCharsetWidth(charset) {
     return FirebirdCharsetWidths[upper] || 1;
 }
 
+function resolveTextEncoding(options) {
+    const encoding = options && options.encoding ? options.encoding.toUpperCase() : Const.DEFAULT_ENCODING;
+    return FirebirdToNodeEncoding[encoding] || Const.DEFAULT_ENCODING.toLowerCase();
+}
+
 //------------------------------------------------------
 
 class SQLVarText {
     decode(data, lowerV13, options) {
         let ret;
+        const textEncoding = resolveTextEncoding(options);
         if (this.subType > 1) {
             // ToDo: with column charset
-            ret = data.readText(this.length, Const.DEFAULT_ENCODING);
+            ret = data.readText(this.length, textEncoding);
             const encoding = options && options.encoding ? options.encoding : 'UTF8';
             const width = getFirebirdCharsetWidth(encoding);
             const charLength = Math.floor(this.length / width);
@@ -42,7 +58,7 @@ class SQLVarText {
             }
         } else if (this.subType === 0) {
             // without charset definition
-            ret = data.readText(this.length, Const.DEFAULT_ENCODING);
+            ret = data.readText(this.length, textEncoding);
             const encoding = options && options.encoding ? options.encoding : 'UTF8';
             const width = getFirebirdCharsetWidth(encoding);
             const charLength = Math.floor(this.length / width);
@@ -74,14 +90,15 @@ class SQLVarNull extends SQLVarText {
 //------------------------------------------------------
 
 class SQLVarString {
-    decode(data, lowerV13) {
+    decode(data, lowerV13, options) {
         let ret;
+        const textEncoding = resolveTextEncoding(options);
         if (this.subType > 1) {
             // ToDo: with column charset
-            ret = data.readString(Const.DEFAULT_ENCODING);
+            ret = data.readString(textEncoding);
         } else if (this.subType === 0) {
             // without charset definition
-            ret = data.readString(Const.DEFAULT_ENCODING);
+            ret = data.readString(textEncoding);
         } else {
             ret = data.readBuffer();
         }

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -1,0 +1,35 @@
+const Xsql = require('../lib/wire/xsqlvar');
+const { XdrReader, XdrWriter } = require('../lib/wire/serialize');
+
+describe('Result text decoding respects connection encoding', () => {
+    it('should decode SQLVarString using WIN1252 connection encoding', () => {
+        const sqlVar = new Xsql.SQLVarString();
+        sqlVar.subType = 2;
+
+        const writer = new XdrWriter(64);
+        writer.addString('TESTE NCM COM Ç Ã É Ú', 'latin1');
+        writer.addInt(0);
+
+        const reader = new XdrReader(writer.getData());
+        const result = sqlVar.decode(reader, true, { encoding: 'WIN1252' });
+
+        expect(result).toBe('TESTE NCM COM Ç Ã É Ú');
+    });
+
+    it('should decode SQLVarText using WIN1252 connection encoding', () => {
+        const sqlVar = new Xsql.SQLVarText();
+        sqlVar.subType = 2;
+
+        const text = 'TESTE NCM COM Ç Ã É Ú';
+        sqlVar.length = Buffer.byteLength(text, 'latin1');
+
+        const writer = new XdrWriter(64);
+        writer.addText(text, 'latin1');
+        writer.addInt(0);
+
+        const reader = new XdrReader(writer.getData());
+        const result = sqlVar.decode(reader, true, { encoding: 'WIN1252' });
+
+        expect(result).toBe(text);
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -16,6 +16,7 @@ module.exports = defineConfig({
             'test/utf8-user-identification.js',
             'test/index.js',
             'test/db-crypt-config.js',
+            'test/encoding.js',
             'test/timezone.js',
             'test/decfloat.js',
             'test/mock-server.js',


### PR DESCRIPTION
## Summary
- make `SQLVarText` decode result text using the connection encoding instead of always using `Const.DEFAULT_ENCODING`
- make `SQLVarString` accept connection options and decode varying text with the same encoding-aware logic
- add a focused unit test covering `WIN1252` result decoding for both fixed and varying text columns

## Why
When a connection is configured with `encoding: "WIN1252"`, regular text result columns can still be decoded through `Const.DEFAULT_ENCODING` (`UTF8`) and come back with broken accented characters.

This change keeps the fix scoped to result decoding and does not change the global default encoding.

Related reports: #283, #311, #336

## Validation
- `npm ci`
- `npx vitest run test/encoding.js test/timezone.js`