### PR TITLE
fix: build TZ instants from epoch ms so DST does not shift them (#423 follow-up)

### DIFF
--- a/src/wire/xsqlvar.ts
+++ b/src/wire/xsqlvar.ts
@@ -750,10 +750,11 @@ export class SQLVarTimeTz extends SQLVarBase {
         data.readInt(); // skip timezone info
 
         if (!lowerV13 || !data.readInt()) {
-            // the wire value is already UTC; no local-offset adjustment
-            var d = new Date(0);
-            d.setMilliseconds(Math.floor(time / 10));
-            return d;
+            // The wire value is already a UTC instant. Construct from epoch milliseconds:
+            // Date's constructor is UTC-based, whereas setMilliseconds() is a *local-time*
+            // setter, so rolling forward from new Date(0) across a DST boundary shifts the
+            // result by the DST delta (see the regression tests in test/timezone.js).
+            return new Date(Math.floor(time / 10));
         }
         return null;
     }
@@ -772,10 +773,11 @@ export class SQLVarTimeTzEx extends SQLVarTimeTz {
         data.readInt(); // skip ext_offset
 
         if (!lowerV13 || !data.readInt()) {
-            // the wire value is already UTC; no local-offset adjustment
-            var d = new Date(0);
-            d.setMilliseconds(Math.floor(time / 10));
-            return d;
+            // The wire value is already a UTC instant. Construct from epoch milliseconds:
+            // Date's constructor is UTC-based, whereas setMilliseconds() is a *local-time*
+            // setter, so rolling forward from new Date(0) across a DST boundary shifts the
+            // result by the DST delta (see the regression tests in test/timezone.js).
+            return new Date(Math.floor(time / 10));
         }
         return null;
     }
@@ -794,10 +796,11 @@ export class SQLVarTimeStampTz extends SQLVarBase {
         data.readInt(); // skip timezone info
 
         if (!lowerV13 || !data.readInt()) {
-            // the wire value is already UTC; no local-offset adjustment
-            var d = new Date(0);
-            d.setMilliseconds((date - DateOffset) * TimeCoeff + Math.floor(time / 10));
-            return d;
+            // The wire value is already a UTC instant. Construct from epoch milliseconds:
+            // Date's constructor is UTC-based, whereas setMilliseconds() is a *local-time*
+            // setter, so rolling forward from new Date(0) across a DST boundary shifts the
+            // result by the DST delta (see the regression tests in test/timezone.js).
+            return new Date((date - DateOffset) * TimeCoeff + Math.floor(time / 10));
         }
 
         return null;
@@ -818,10 +821,11 @@ export class SQLVarTimeStampTzEx extends SQLVarTimeStampTz {
         data.readInt(); // skip ext_offset
 
         if (!lowerV13 || !data.readInt()) {
-            // the wire value is already UTC; no local-offset adjustment
-            var d = new Date(0);
-            d.setMilliseconds((date - DateOffset) * TimeCoeff + Math.floor(time / 10));
-            return d;
+            // The wire value is already a UTC instant. Construct from epoch milliseconds:
+            // Date's constructor is UTC-based, whereas setMilliseconds() is a *local-time*
+            // setter, so rolling forward from new Date(0) across a DST boundary shifts the
+            // result by the DST delta (see the regression tests in test/timezone.js).
+            return new Date((date - DateOffset) * TimeCoeff + Math.floor(time / 10));
         }
 
         return null;

--- a/test/timezone.js
+++ b/test/timezone.js
@@ -160,4 +160,59 @@ describe('Timezone Support (Firebird 4.0)', () => {
             expect(result).toBeNull();
         });
     });
+    // #423 follow-up: every test above decodes a value on 1970-01-01, which is the epoch the
+    // decoder built its Date from — so a local-time rounding error cancels out and cannot be
+    // observed. These decode a mid-year instant instead, in a timezone that observes DST, which
+    // is where `new Date(0)` + `setMilliseconds()` (a *local-time* setter) drifts by the DST
+    // delta. TZ is set per-test so the result does not depend on the machine running the suite.
+    describe('DST correctness (regression for the #423 follow-up)', () => {
+        const originalTZ = process.env.TZ;
+        afterEach(() => { process.env.TZ = originalTZ; });
+
+        // 2026-07-31T12:00:00Z — inside DST for a northern-hemisphere zone.
+        const SUMMER_DAYS = Math.floor(Date.UTC(2026, 6, 31) / TimeCoeff) + DateOffset;
+        const NOON_MS = 12 * 60 * 60 * 1000;
+
+        function decodeTimestampTz(tz) {
+            process.env.TZ = tz;
+            const sqlVar = new Xsql.SQLVarTimeStampTz();
+            const buffer = Buffer.alloc(16);
+            buffer.writeInt32BE(SUMMER_DAYS, 0);
+            buffer.writeUInt32BE(NOON_MS * 10, 4); // deci-milliseconds
+            buffer.writeInt32BE(1, 8);
+            buffer.writeInt32BE(0, 12);
+            return sqlVar.decode(new XdrReader(buffer), true);
+        }
+
+        it('decodes a summer TIMESTAMP WITH TIME ZONE as the same instant in a DST zone', () => {
+            // Fails without the fix: the epoch reference is in winter (UTC+2) while the value is
+            // in summer (UTC+3), so the result lands an hour early at 11:00Z.
+            expect(decodeTimestampTz('Europe/Bucharest').toISOString()).toBe('2026-07-31T12:00:00.000Z');
+        });
+
+        it('decodes the same value identically in a southern-hemisphere DST zone', () => {
+            // Same instant, opposite DST phase — the decoded value must not depend on the client.
+            expect(decodeTimestampTz('Australia/Sydney').toISOString()).toBe('2026-07-31T12:00:00.000Z');
+        });
+
+        it('decodes the same value identically with no DST at all', () => {
+            expect(decodeTimestampTz('UTC').toISOString()).toBe('2026-07-31T12:00:00.000Z');
+            expect(decodeTimestampTz('America/Sao_Paulo').toISOString()).toBe('2026-07-31T12:00:00.000Z');
+        });
+
+        it('decodes TIME WITH TIME ZONE independently of the client timezone', () => {
+            const decodeTimeTz = tz => {
+                process.env.TZ = tz;
+                const sqlVar = new Xsql.SQLVarTimeTz();
+                const buffer = Buffer.alloc(12);
+                buffer.writeUInt32BE(NOON_MS * 10, 0);
+                buffer.writeInt32BE(1, 4);
+                buffer.writeInt32BE(0, 8);
+                return sqlVar.decode(new XdrReader(buffer), true);
+            };
+            for (const tz of ['UTC', 'Europe/Bucharest', 'Australia/Sydney', 'America/Sao_Paulo']) {
+                expect(decodeTimeTz(tz).getUTCHours(), `TIME WITH TIME ZONE in ${tz}`).toBe(12);
+            }
+        });
+    });
 });


### PR DESCRIPTION
Follow-up to #423 / dd145cc. That fix removed the client-offset adjustment from the `TIME`/`TIMESTAMP WITH TIME ZONE` decoders, but kept constructing the `Date` as `new Date(0)` followed by `setMilliseconds(...)`.

`setMilliseconds()` is a **local-time** setter. Rolling forward from the epoch lands in a different DST phase than the epoch itself whenever the target instant is on the other side of a DST boundary, so the result is off by the DST delta. `Date`'s constructor takes epoch milliseconds directly and has no such dependency.

### Repro (no Firebird involved)

```console
$ TZ=Europe/Bucharest node -e '
    const ms = Date.UTC(2026, 6, 31, 12, 0, 0);
    const d = new Date(0); d.setMilliseconds(ms);
    console.log(d.toISOString(), new Date(ms).toISOString());
  '
2026-07-31T11:00:00.000Z 2026-07-31T12:00:00.000Z
```

### Against a real server

Firebird 6.0, client in `Europe/Bucharest` (UTC+3 in July, UTC+2 in January):

```sql
SELECT CAST('2026-07-31 12:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE) FROM RDB$DATABASE
```

| version | result | |
|---|---|---|
| 2.14.0 | `2026-07-31T09:00:00.000Z` | off by the full client offset |
| 2.14.1 | `2026-07-31T11:00:00.000Z` | off by the DST hour |
| this PR | `2026-07-31T12:00:00.000Z` | ✅ |

A January value (`2026-01-15 12:00 UTC`) already decoded correctly on 2.14.1 and still does — outside DST there is no drift, which is why this survived the original fix.

### Why the existing tests didn't catch it

Every case in `test/timezone.js` decodes a value on **1970-01-01** — the very epoch the decoder starts from — so the local-time round trip cancels out and the bug cannot be observed. It also can't be observed from a zone that doesn't observe DST, which includes `-0300` Brazil, the zone in the original #423 report.

The added tests decode a mid-year instant and set `process.env.TZ` per test, so they're deterministic regardless of the machine running the suite. On 2.14.1 the first one fails with:

```
AssertionError: expected '2026-07-31T11:00:00.000Z' to be '2026-07-31T12:00:00.000Z'
```

### Scope

Only the four `WITH TIME ZONE` decoders are touched (`SQLVarTimeTz`, `SQLVarTimeTzEx`, `SQLVarTimeStampTz`, `SQLVarTimeStampTzEx`). The zoneless `DATE`/`TIME`/`TIMESTAMP` decoders above them still apply the client offset deliberately and are left alone.

### Verification

- `npx vitest run test/timezone.js` → 14 passed (10 existing + 4 new)
- Full `npx vitest run`: **50 failed / 488 passed**, identical failure count to unpatched `master` (**50 failed / 484 passed**) — those failures are the suites needing a live server on this machine, not this change
- `npm run lint` → 0 errors
- Patched build queried against a real Firebird 6.0 server, results in the table above
