### PR TITLE
fix(charset): use true Windows-1252 encoding for WIN1252

### DIFF
--- a/README.md
+++ b/README.md
@@ -1563,7 +1563,8 @@ Commonly used Firebird character sets are automatically mapped to their correspo
 | Firebird Character Set | Node.js Buffer Encoding | Description / Notes |
 | ---------------------- | ----------------------- | ------------------- |
 | `UTF8`, `UNICODE_FSS`  | `utf8`                  | Unicode. Handles character-level truncation automatically based on charset width. |
-| `WIN1252`, `ISO8859_1`, `LATIN1` | `latin1`      | 8-bit European encodings. Safely decodes special accented characters. |
+| `WIN1252`             | ICU `windows-1252` codec | Windows Western European encoding, including the printable characters in bytes `0x80`–`0x9F`. |
+| `ISO8859_1`, `LATIN1` | `latin1`                  | ISO-8859-1-compatible byte mapping; intentionally distinct from Windows-1252. |
 | `ASCII`                | `ascii`                 | 7-bit ASCII. |
 | `NONE`                 | `latin1`                | Raw/unspecified character set. Treated as binary-safe 8-bit characters. |
 
@@ -1597,7 +1598,7 @@ var options = {
     database: 'win1252_db.fdb',
     user: 'SYSDBA',
     password: 'masterkey',
-    encoding: 'WIN1252' // Automatically maps to 'latin1' under the hood
+    encoding: 'WIN1252' // Uses the WHATWG/ICU Windows-1252 codec
 };
 
 Firebird.attach(options, function (err, db) {
@@ -2296,7 +2297,7 @@ options.blobReadChunkSize = 65535;
 
 If your server and client are on the same host, this won't matter much — the slowdown is latency-bound, not throughput-bound.
 
-#### How do I use an encoding other than UTF-8 (e.g. WIN1252/Latin1)?
+#### How do I use an encoding other than UTF-8 (e.g. WIN1252 or Latin1)?
 
 Set `options.encoding` — no source changes required (see [Character Set & Encoding Support](#character-set--encoding-support) for the full mapping table):
 

--- a/README.md
+++ b/README.md
@@ -1582,7 +1582,9 @@ await db.queryAsync('INSERT INTO T VALUES (?)', ['Привет']); // encoded as
 ```
 
 The codecs are built from Node's ICU tables at first use (present in every
-official Node build). `attachOrCreate`/`create` honour `options.encoding`
+official Node build). If a constrained runtime does not provide a requested
+codec, the driver throws a descriptive error instead of silently falling back
+to UTF-8 and corrupting text. `attachOrCreate`/`create` honour `options.encoding`
 for the new database's default charset too. Accented characters and
 fixed-length `CHAR(N)` whitespace/truncation are handled automatically per
 the charset width — and single-byte columns (including charset `NONE`) are

--- a/README.md
+++ b/README.md
@@ -1558,15 +1558,15 @@ fb.attach(_connection, function (err, svc) {
 
 Node-Firebird defaults to `UTF-8` for database connections, but fully supports custom client character sets. You can set the connection encoding by specifying `options.encoding` (e.g. `'UTF8'`, `'WIN1252'`, `'ISO8859_1'`, `'LATIN1'`, `'ASCII'`, or `'NONE'`).
 
-Commonly used Firebird character sets are automatically mapped to their corresponding Node.js Buffer encodings:
+Commonly used Firebird character sets are handled through the corresponding Node.js encoding or ICU codec:
 
-| Firebird Character Set | Node.js Buffer Encoding | Description / Notes |
-| ---------------------- | ----------------------- | ------------------- |
-| `UTF8`, `UNICODE_FSS`  | `utf8`                  | Unicode. Handles character-level truncation automatically based on charset width. |
-| `WIN1252`             | ICU `windows-1252` codec | Windows Western European encoding, including the printable characters in bytes `0x80`–`0x9F`. |
-| `ISO8859_1`, `LATIN1` | `latin1`                  | ISO-8859-1-compatible byte mapping; intentionally distinct from Windows-1252. |
-| `ASCII`                | `ascii`                 | 7-bit ASCII. |
-| `NONE`                 | `latin1`                | Raw/unspecified character set. Treated as binary-safe 8-bit characters. |
+| Firebird Character Set | Node.js encoding / ICU codec | Description / Notes |
+| ---------------------- | ---------------------------- | ------------------- |
+| `UTF8`, `UNICODE_FSS`  | `utf8`                       | Unicode. Handles character-level truncation automatically based on charset width. |
+| `WIN1252`              | ICU `windows-1252` codec     | Windows Western European encoding, including the printable characters in bytes `0x80`–`0x9F`. |
+| `ISO8859_1`, `LATIN1`  | `latin1`                     | ISO-8859-1-compatible byte mapping; intentionally distinct from Windows-1252. |
+| `ASCII`                | `ascii`                      | 7-bit ASCII. |
+| `NONE`                 | `latin1`                     | Raw/unspecified character set. Treated as binary-safe 8-bit characters. |
 
 Beyond Node's native encodings, the driver ships **codepage codecs** for the
 single-byte charsets (decode *and* encode — columns, parameters, SQL

--- a/src/wire/codepages.ts
+++ b/src/wire/codepages.ts
@@ -21,6 +21,7 @@ export interface TextCodec {
 const ICU_LABELS: Readonly<Record<string, string>> = Object.freeze({
     WIN1250: 'windows-1250',
     WIN1251: 'windows-1251',
+    WIN1252: 'windows-1252',
     WIN1253: 'windows-1253',
     WIN1254: 'windows-1254',
     WIN1255: 'windows-1255',

--- a/src/wire/codepages.ts
+++ b/src/wire/codepages.ts
@@ -78,8 +78,15 @@ function buildCodec(name: string): TextCodec | null {
     try {
         decoder = new TextDecoder(label);
     } catch {
-        // Node built with small-icu: legacy encodings unavailable
-        return null;
+        // Falling through to DEFAULT_ENCODING (UTF-8) would silently write
+        // different bytes from the explicitly requested Firebird codepage.
+        // Official Node builds include these ICU tables; constrained builds
+        // must fail clearly instead of corrupting text.
+        throw new Error(
+            `The requested Firebird encoding ${name} requires the ${label} ICU codec, ` +
+            'but this Node.js runtime does not provide it. Use an official full-ICU ' +
+            'Node.js build, or connect with encoding NONE and pass explicitly encoded Buffer values.'
+        );
     }
 
     // Build both directions from the decoder, one byte at a time — every
@@ -131,8 +138,10 @@ function buildCodec(name: string): TextCodec | null {
 }
 
 /**
- * Codec for a Firebird charset name, or null when the charset is unknown,
- * natively handled by Buffer, or the ICU tables are unavailable. Cached.
+ * Codec for a Firebird charset name, or null when the charset is unknown or
+ * natively handled by Buffer. A known codepage whose ICU table is unavailable
+ * throws instead of silently falling back to UTF-8. Successful and unknown
+ * lookups are cached; failures are not.
  */
 export function getCodec(charsetName: string | undefined): TextCodec | null {
     if (!charsetName) {

--- a/src/wire/xsqlvar.ts
+++ b/src/wire/xsqlvar.ts
@@ -29,8 +29,9 @@ const EMPTY_BUFFER = Buffer.alloc(0);
  * We must decode raw bytes with the matching Node.js encoding so that
  * characters outside ASCII are reproduced correctly.
  *
- * Commonly used Firebird charsets not listed here fall back to the
- * connection-level DEFAULT_ENCODING (typically 'utf8').
+ * Other recognized single-byte character sets are handled by the ICU-backed
+ * codec path. Only unknown character-set names fall back to the
+ * connection-level DEFAULT_ENCODING, typically UTF-8.
  */
 const FirebirdToNodeEncoding: Readonly<Record<string, string>> = Object.freeze({
     UTF8:        'utf8',

--- a/src/wire/xsqlvar.ts
+++ b/src/wire/xsqlvar.ts
@@ -35,7 +35,6 @@ const EMPTY_BUFFER = Buffer.alloc(0);
 const FirebirdToNodeEncoding: Readonly<Record<string, string>> = Object.freeze({
     UTF8:        'utf8',
     UNICODE_FSS: 'utf8',
-    WIN1252:     'latin1',
     ISO8859_1:   'latin1',
     LATIN1:      'latin1',
     ASCII:       'ascii',

--- a/test/codepages.js
+++ b/test/codepages.js
@@ -45,6 +45,25 @@ async function withDb(extra, work) {
 }
 
 describe('single-byte codepage support', function () {
+    it('WIN1252 connection round-trips a NONE database without treating it as Latin-1', async function () {
+        await withDb({ encoding: 'WIN1252', defaultCharset: 'NONE', blobAsText: true }, async (db) => {
+            const text = '€ “Windows” — Œuvre ™ ŠŽŸ';
+            await db.queryAsync('CREATE TABLE W (V VARCHAR(80), C CHAR(20), B BLOB SUB_TYPE TEXT)');
+            await db.queryAsync('INSERT INTO W VALUES (?, ?, ?)', [text, '€—™', text]);
+
+            const rows = await db.queryAsync('SELECT V, C, B FROM W WHERE V = ?', [text]);
+            assert.strictEqual(rows.length, 1);
+            assert.strictEqual(rows[0].V, text);
+            assert.strictEqual(rows[0].C.trimEnd(), '€—™');
+            assert.strictEqual(rows[0].B, text);
+
+            const literal = await db.queryAsync("SELECT COUNT(*) C FROM W WHERE V = '€ “Windows” — Œuvre ™ ŠŽŸ'");
+            assert.strictEqual(Number(literal[0].C), 1);
+            const charset = await db.queryAsync('SELECT TRIM(RDB$CHARACTER_SET_NAME) CS FROM RDB$DATABASE');
+            assert.strictEqual(charset[0].CS, 'NONE');
+        });
+    });
+
     it('#422: NONE/ASCII columns read fully under the default UTF8 connection', async function () {
         await withDb({}, async (db) => {
             const r = await db.queryAsync("select cast('abcd' as varchar(15) character set none) v from rdb$database");

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -15,6 +15,7 @@
 const assert = require('assert');
 const { SQLVarText, SQLVarString } = require('../lib/wire/xsqlvar');
 const { XdrReader, XdrWriter } = require('../lib/wire/serialize');
+const { getCodec } = require('../lib/wire/codepages');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -38,6 +39,14 @@ function makeStringReader(text, nodeEncoding) {
     const w = new XdrWriter(256);
     w.addString(text, nodeEncoding);
     w.addInt(0); // null-indicator: 0 = not null
+    return new XdrReader(w.getData());
+}
+
+function makeTextReaderFromBytes(bytes) {
+    const w = new XdrWriter(256);
+    w.addBuffer(bytes);
+    w.addAlignment(bytes.length);
+    w.addInt(0);
     return new XdrReader(w.getData());
 }
 
@@ -70,16 +79,28 @@ describe('resolveTextEncoding (via SQLVarText.decode)', function () {
         assert.strictEqual(result, text);
     });
 
-    it('maps WIN1252 → latin1 and decodes special characters correctly', function () {
-        // These chars exist in WIN1252 / ISO-8859-1 but need latin1 decoding.
-        const text = 'Ç Ã É Ú';
+    it('maps WIN1252 through the real Windows-1252 codec', function () {
+        const text = '€ “Windows” — Œuvre ™';
+        const bytes = getCodec('WIN1252').encode(text);
         const sqlVar = new SQLVarText();
         sqlVar.subType = 0;
-        sqlVar.length = Buffer.byteLength(text, 'latin1');
+        sqlVar.length = bytes.length;
 
-        const reader = makeTextReader(text, 'latin1');
+        const reader = makeTextReaderFromBytes(bytes);
         const result = sqlVar.decode(reader, false, { encoding: 'WIN1252' });
         assert.strictEqual(result, text);
+    });
+
+    it('does not interpret WIN1252 extension bytes as ISO-8859-1', function () {
+        const bytes = Buffer.from([0x80, 0x91, 0x92, 0x96, 0x97]);
+        const sqlVar = new SQLVarText();
+        sqlVar.subType = 0;
+        sqlVar.length = bytes.length;
+
+        const cp1252 = sqlVar.decode(makeTextReaderFromBytes(bytes), false, { encoding: 'WIN1252' });
+        const latin1 = sqlVar.decode(makeTextReaderFromBytes(bytes), false, { encoding: 'ISO8859_1' });
+        assert.strictEqual(cp1252, '€‘’–—');
+        assert.notStrictEqual(cp1252, latin1);
     });
 
     it('maps ISO8859_1 → latin1', function () {

--- a/test/unit/codepages.test.ts
+++ b/test/unit/codepages.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { charsetWidthById, getCodec } from '../../src/wire/codepages';
+import { resolveTextState } from '../../src/wire/xsqlvar';
 
 describe('codepage codecs', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
     it('encodes and decodes the complete printable WIN1252 extension range', () => {
         const c = getCodec('WIN1252')!;
         const text = '€‚ƒ„…†‡ˆ‰Š‹ŒŽ‘’“”•–—˜™š›œžŸ';
@@ -39,6 +44,22 @@ describe('codepage codecs', () => {
     it('returns null for unknown charsets and caches results', () => {
         expect(getCodec('NO_SUCH_CHARSET')).toBeNull();
         expect(getCodec('WIN1253')).toBe(getCodec('win1253')); // case-insensitive, cached
+    });
+
+    it('fails explicitly when a requested codepage codec is unavailable and does not cache the failure', () => {
+        const NativeTextDecoder = TextDecoder;
+        vi.stubGlobal('TextDecoder', class {
+            constructor(label: string) {
+                throw new RangeError(`Unsupported encoding: ${label}`);
+            }
+        });
+
+        expect(() => resolveTextState({ encoding: 'WIN1258' })).toThrow(
+            /Firebird encoding WIN1258 requires the windows-1258 ICU codec/
+        );
+
+        vi.stubGlobal('TextDecoder', NativeTextDecoder);
+        expect(resolveTextState({ encoding: 'WIN1258' }).codec).toBeTruthy();
     });
 
     it('knows multi-byte charset widths by id', () => {

--- a/test/unit/codepages.test.ts
+++ b/test/unit/codepages.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, it } from 'vitest';
 import { charsetWidthById, getCodec } from '../../src/wire/codepages';
 
 describe('codepage codecs', () => {
+    it('encodes and decodes the complete printable WIN1252 extension range', () => {
+        const c = getCodec('WIN1252')!;
+        const text = '€‚ƒ„…†‡ˆ‰Š‹ŒŽ‘’“”•–—˜™š›œžŸ';
+        const bytes = Buffer.from('8082838485868788898a8b8c8e9192939495969798999a9b9c9e9f', 'hex');
+
+        expect(c).toBeTruthy();
+        expect(c.encode(text)).toEqual(bytes);
+        expect(c.decode(bytes)).toBe(text);
+        expect(getCodec('win1252')).toBe(c);
+    });
+
     it('round-trips greek through WIN1253', () => {
         const c = getCodec('WIN1253')!;
         expect(c).toBeTruthy();
@@ -22,6 +33,7 @@ describe('codepage codecs', () => {
     it('replaces unmappable characters with ? on encode', () => {
         const c = getCodec('WIN1253')!;
         expect(c.encode('a日b').toString('latin1')).toBe('a?b');
+        expect(getCodec('WIN1252')!.encode('a日b').toString('latin1')).toBe('a?b');
     });
 
     it('returns null for unknown charsets and caches results', () => {


### PR DESCRIPTION
# fix(charset): use true Windows-1252 encoding for WIN1252

## Summary

This fixes Firebird `WIN1252` connections by routing them through the existing
ICU/WHATWG `windows-1252` codec instead of Node.js `latin1`.

It also:

- Keeps `ISO8859_1` and `LATIN1` on their existing Latin-1 mapping.
- Covers SQL text, parameters, returned text columns, and textual BLOBs through
  the existing codec path.
- Preserves byte-for-byte `Buffer` pass-through.
- Throws a descriptive error when a requested ICU codepage is unavailable,
  instead of silently falling back to UTF-8.
- Updates the charset documentation and examples.
- Adds unit and Firebird integration regression tests.

## Why this is needed

Windows-1252 and ISO-8859-1/Node.js `latin1` are not equivalent.

They differ particularly in the `0x80`-`0x9F` range. Windows-1252 uses this
range for characters including:

- `€`
- Smart quotes
- En and em dashes
- `Œ/œ`
- `Š/š`
- `Ž/ž`
- `™`
- `Ÿ`

With the current `WIN1252` to `latin1` mapping, these characters are encoded
to incorrect bytes when written and are returned as control characters when
real Windows-1252 bytes are read.

For example, this string does not round-trip correctly with the current
mapping:

```text
€ “Windows” — Œuvre ™ ŠŽŸ
```

This affects databases genuinely declared as `WIN1252`. 

## Implementation

- Adds `WIN1252: 'windows-1252'` to the existing ICU codec table.
- Removes `WIN1252` from the native Node.js `latin1` mapping.
- Leaves `ISO8859_1`, `LATIN1`, and `NONE` unchanged.
- Uses the existing codepage codec implementation and cache.
- Fails explicitly if a constrained Node.js runtime lacks a requested ICU
  codec, rather than encoding the text as UTF-8.

## Tests

Coverage includes:

- Exact encoding and decoding of the defined printable Windows-1252
  characters in the `0x80`-`0x9F` range.
- Verification that Windows-1252 extension bytes are not interpreted as
  ISO-8859-1.
- Case-insensitive codec lookup and caching.
- Replacement of unmappable Unicode input.
- Failure behavior when an ICU codec is unavailable.
- Firebird round trips through `VARCHAR`, `CHAR`, parameters, SQL literals,
  and `BLOB SUB_TYPE TEXT`.
- A Firebird database using `CHARSET NONE` with a `WIN1252` client connection.
- Confirmation that existing Latin-1 behavior remains unchanged.

Validated with:

```shell
npm run build
npm run typecheck
npm run lint
npx vitest run test/unit/codepages.test.ts test/encoding.js test/codepages.js
```

The focused test run completed with 43 passing tests and one existing skipped
test. Lint completed with zero errors.

I also reproduced the original behavior and verified the fix against
Firebird 3 using a database declared as `WIN1252`.
