### PR TITLE
feat(numeric): add configurable exact result modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ options.jsonAsObject = false; // optional; automatically stringify parameters an
 options.namedPlaceholders = false; // set to true to allow :name placeholders in SQL with a { name: value } params object (see Named placeholders)
 options.nestTables = false; // true nests object rows by source table (row[table][column]); a string separator flattens to 'table<sep>column' keys — see Nested result tables (nestTables). Overridable per query
 options.transformKeys = undefined; // 'camel' (FIRST_NAME → firstName) or a (key) => key mapper for object-row keys — see Transforming row keys (transformKeys). Overridable per query
-options.numericMode = Firebird.NUMERIC_MODE_LEGACY; // INT64/INT128 result policy: LEGACY (default), SAFE, or STRING
+options.numericMode = Firebird.NUMERIC_MODE_LOSSY; // INT64/INT128 result policy: LOSSY (default), SAFE, or STRING
 options.typeCast = undefined; // optional; custom type parser called for every result column value (see Custom type parsers)
 options.statementCacheSize = 0; // optional; per-connection LRU cache of prepared statements, 0 = disabled (see Prepared-statement cache)
 ```
@@ -746,13 +746,19 @@ them as signed integer coefficients plus a decimal scale. JavaScript numbers
 cannot represent every INT64 or INT128 coefficient exactly. The connection
 option `numericMode` controls how those result values are exposed:
 
-| Mode | Safe coefficient | Unsafe coefficient |
-| :--- | :--- | :--- |
-| `Firebird.NUMERIC_MODE_LEGACY` | Existing node-firebird behavior | Existing node-firebird behavior |
-| `Firebird.NUMERIC_MODE_SAFE` | `number` | Exact scaled `string` |
-| `Firebird.NUMERIC_MODE_STRING` | Exact scaled `string` | Exact scaled `string` |
+| Mode | Result policy |
+| :--- | :--- |
+| `Firebird.NUMERIC_MODE_LOSSY` | INT64-backed values are returned as `number`; INT128 uses a mixed `number`/`string` path. Unsafe coefficients may lose precision. |
+| `Firebird.NUMERIC_MODE_SAFE` | Safe coefficients are returned as `number`; unsafe coefficients as exact scaled `string`. |
+| `Firebird.NUMERIC_MODE_STRING` | All values are returned as exact scaled `string`. |
 
-`LEGACY` is the default, so upgrading does not change existing result types.
+`LOSSY` decodes INT64-backed values through JavaScript `Number`. INT128 uses a
+mixed number/string decoding path. For coefficients outside JavaScript's safe
+integer range, the result type can depend on the Firebird wire type and value,
+and numeric precision is not guaranteed. `LOSSY` remains the default so that
+adding `numericMode` does not silently change result types for applications
+upgrading from earlier node-firebird releases.
+
 `SAFE` tests the raw integer coefficient against JavaScript's inclusive safe
 range (`Number.MIN_SAFE_INTEGER` through `Number.MAX_SAFE_INTEGER`) before
 applying its scale. `STRING` provides a stable result type and retains zeroes
@@ -768,7 +774,7 @@ const db = await Firebird.attachAsync({
 // DECIMAL coefficient 420000,-4 -> '42.0000'
 ```
 
-The string literals `'legacy'`, `'safe'`, and `'string'` are accepted too,
+The string literals `'lossy'`, `'safe'`, and `'string'` are accepted too,
 including in connection URIs (`?numericMode=safe`). `NULL` remains `null` in
 every mode. The option does not change `FLOAT`, `DOUBLE`, `DECFLOAT`, or input
 parameter encoding. A `SAFE` result returned as a number still has the normal
@@ -816,7 +822,7 @@ Firebird.attach({
 Notes:
 
 - The hook runs after [`numericMode`](#fixed-point-numeric-results-numericmode).
-  Calling `String(next())` cannot recover digits already lost by legacy
+  Calling `String(next())` cannot recover digits already lost by lossy
   numeric decoding; select `SAFE` or `STRING` when exact coefficients matter.
 - Non-text BLOB columns reach the hook as the usual asynchronous fetch
   function; text BLOBs with `blobAsText: true` reach it as the resolved

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ options.jsonAsObject = false; // optional; automatically stringify parameters an
 options.namedPlaceholders = false; // set to true to allow :name placeholders in SQL with a { name: value } params object (see Named placeholders)
 options.nestTables = false; // true nests object rows by source table (row[table][column]); a string separator flattens to 'table<sep>column' keys — see Nested result tables (nestTables). Overridable per query
 options.transformKeys = undefined; // 'camel' (FIRST_NAME → firstName) or a (key) => key mapper for object-row keys — see Transforming row keys (transformKeys). Overridable per query
+options.numericMode = Firebird.NUMERIC_MODE_LEGACY; // INT64/INT128 result policy: LEGACY (default), SAFE, or STRING
 options.typeCast = undefined; // optional; custom type parser called for every result column value (see Custom type parsers)
 options.statementCacheSize = 0; // optional; per-connection LRU cache of prepared statements, 0 = disabled (see Prepared-statement cache)
 ```
@@ -738,6 +739,42 @@ on databases and transactions alike. It is ignored by the streaming APIs
 PROCEDURE`, `affectedRows` reflects DML the procedure performed — a
 procedure that only returns values reports 0 alongside its row.
 
+### Fixed-point numeric results (numericMode)
+
+Firebird sends `BIGINT`, `INT128`, and the `NUMERIC`/`DECIMAL` types backed by
+them as signed integer coefficients plus a decimal scale. JavaScript numbers
+cannot represent every INT64 or INT128 coefficient exactly. The connection
+option `numericMode` controls how those result values are exposed:
+
+| Mode | Safe coefficient | Unsafe coefficient |
+| :--- | :--- | :--- |
+| `Firebird.NUMERIC_MODE_LEGACY` | Existing node-firebird behavior | Existing node-firebird behavior |
+| `Firebird.NUMERIC_MODE_SAFE` | `number` | Exact scaled `string` |
+| `Firebird.NUMERIC_MODE_STRING` | Exact scaled `string` | Exact scaled `string` |
+
+`LEGACY` is the default, so upgrading does not change existing result types.
+`SAFE` tests the raw integer coefficient against JavaScript's inclusive safe
+range (`Number.MIN_SAFE_INTEGER` through `Number.MAX_SAFE_INTEGER`) before
+applying its scale. `STRING` provides a stable result type and retains zeroes
+implied by the declared scale:
+
+```js
+const db = await Firebird.attachAsync({
+    ...options,
+    numericMode: Firebird.NUMERIC_MODE_STRING,
+});
+
+// BIGINT 42                     -> '42'
+// DECIMAL coefficient 420000,-4 -> '42.0000'
+```
+
+The string literals `'legacy'`, `'safe'`, and `'string'` are accepted too,
+including in connection URIs (`?numericMode=safe`). `NULL` remains `null` in
+every mode. The option does not change `FLOAT`, `DOUBLE`, `DECFLOAT`, or input
+parameter encoding. A `SAFE` result returned as a number still has the normal
+IEEE-754 behavior of JavaScript fractional numbers; use `STRING` when the
+decimal representation itself must remain exact.
+
 ### Custom type parsers (typeCast)
 
 The `typeCast` connection option lets you override how column values are
@@ -757,10 +794,6 @@ Firebird.attach({
         if (column.typeName === 'DATE') {
             const v = next();
             return v === null ? null : v.toISOString().slice(0, 10);
-        }
-        // BIGINT columns as strings
-        if (column.type === Firebird.SQL_TYPES.SQL_INT64 && !column.scale) {
-            return String(next());
         }
         return next(); // everything else: default decoding
     },
@@ -782,6 +815,9 @@ Firebird.attach({
 
 Notes:
 
+- The hook runs after [`numericMode`](#fixed-point-numeric-results-numericmode).
+  Calling `String(next())` cannot recover digits already lost by legacy
+  numeric decoding; select `SAFE` or `STRING` when exact coefficients matter.
 - Non-text BLOB columns reach the hook as the usual asynchronous fetch
   function; text BLOBs with `blobAsText: true` reach it as the resolved
   string.

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,8 +35,8 @@ export const AUTH_PLUGIN_SRP512: string = Const.AUTH_PLUGIN_SRP512;
 export const WIRE_CRYPT_DISABLE: number = Const.WIRE_CRYPT_DISABLE;
 export const WIRE_CRYPT_ENABLE: number = Const.WIRE_CRYPT_ENABLE;
 
-/** Preserve the result types produced by older node-firebird releases. */
-export const NUMERIC_MODE_LEGACY = Const.NUMERIC_MODE_LEGACY;
+/** Decode through JavaScript Number where applicable; unsafe coefficients may lose precision. */
+export const NUMERIC_MODE_LOSSY = Const.NUMERIC_MODE_LOSSY;
 /** Return safe INT64/INT128 coefficients as numbers and unsafe ones as exact strings. */
 export const NUMERIC_MODE_SAFE = Const.NUMERIC_MODE_SAFE;
 /** Return every INT64/INT128-backed fixed-point value as an exact string. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,13 @@ export const AUTH_PLUGIN_SRP512: string = Const.AUTH_PLUGIN_SRP512;
 export const WIRE_CRYPT_DISABLE: number = Const.WIRE_CRYPT_DISABLE;
 export const WIRE_CRYPT_ENABLE: number = Const.WIRE_CRYPT_ENABLE;
 
+/** Preserve the result types produced by older node-firebird releases. */
+export const NUMERIC_MODE_LEGACY = Const.NUMERIC_MODE_LEGACY;
+/** Return safe INT64/INT128 coefficients as numbers and unsafe ones as exact strings. */
+export const NUMERIC_MODE_SAFE = Const.NUMERIC_MODE_SAFE;
+/** Return every INT64/INT128-backed fixed-point value as an exact string. */
+export const NUMERIC_MODE_STRING = Const.NUMERIC_MODE_STRING;
+
 /** A transaction sees changes done by uncommitted transactions. */
 export const ISOLATION_READ_UNCOMMITTED: number[] = Const.ISOLATION_READ_UNCOMMITTED;
 /** A transaction sees only data committed before the statement has been executed. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,9 @@ export interface ColumnMetadata {
 
 export type Isolation = number[];
 
+/** Result conversion policy for INT64/INT128-backed fixed-point values. */
+export type NumericMode = 'legacy' | 'safe' | 'string';
+
 export type TransactionOptions = {
     autoCommit?: boolean;
     autoUndo?: boolean;
@@ -433,6 +436,16 @@ export interface Options {
      */
     blobReadChunkSize?: number;
     wireCrypt?: number; // WIRE_CRYPT_DISABLE or WIRE_CRYPT_ENABLE
+    /**
+     * Result conversion policy for BIGINT/INT128 and fixed-point
+     * NUMERIC/DECIMAL values backed by them.
+     *
+     * - `legacy` (default) preserves the result types of older releases.
+     * - `safe` returns a number when the raw integer coefficient is within
+     *   JavaScript's safe range, otherwise an exact scaled string.
+     * - `string` always returns an exact scaled string.
+     */
+    numericMode?: NumericMode;
     wireCompression?: boolean;
     /**
      * Enable named placeholders: SQL may use `:name` markers and params may

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,7 @@ export interface ColumnMetadata {
 export type Isolation = number[];
 
 /** Result conversion policy for INT64/INT128-backed fixed-point values. */
-export type NumericMode = 'legacy' | 'safe' | 'string';
+export type NumericMode = 'lossy' | 'safe' | 'string';
 
 export type TransactionOptions = {
     autoCommit?: boolean;
@@ -440,7 +440,8 @@ export interface Options {
      * Result conversion policy for BIGINT/INT128 and fixed-point
      * NUMERIC/DECIMAL values backed by them.
      *
-     * - `legacy` (default) preserves the result types of older releases.
+     * - `lossy` (default) decodes through JavaScript `Number` where
+     *   applicable; unsafe coefficients may lose precision.
      * - `safe` returns a number when the raw integer coefficient is within
      *   JavaScript's safe range, otherwise an exact scaled string.
      * - `string` always returns an exact scaled string.

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -202,10 +202,10 @@ export function normalizeOptions<T>(options: T | string): T {
     }
     const normalized = applyEnvDefaults(options as any);
     const numericMode = normalized && normalized.numericMode;
-    if (numericMode !== undefined && numericMode !== 'legacy' &&
+    if (numericMode !== undefined && numericMode !== 'lossy' &&
         numericMode !== 'safe' && numericMode !== 'string') {
         throw new Error('Invalid numericMode option: ' + numericMode +
-            ' (expected "legacy", "safe", or "string")');
+            ' (expected "lossy", "safe", or "string")');
     }
     return normalized;
 }

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -200,7 +200,14 @@ export function normalizeOptions<T>(options: T | string): T {
     if (typeof options === 'string') {
         options = parseConnectionString(options) as T;
     }
-    return applyEnvDefaults(options as any);
+    const normalized = applyEnvDefaults(options as any);
+    const numericMode = normalized && normalized.numericMode;
+    if (numericMode !== undefined && numericMode !== 'legacy' &&
+        numericMode !== 'safe' && numericMode !== 'string') {
+        throw new Error('Invalid numericMode option: ' + numericMode +
+            ' (expected "legacy", "safe", or "string")');
+    }
+    return normalized;
 }
 
 /**

--- a/src/wire/const.ts
+++ b/src/wire/const.ts
@@ -25,6 +25,12 @@ const int = {
     MIN_INT : -Math.pow(2, 31),
 };
 
+const numericMode = {
+    NUMERIC_MODE_LEGACY : 'legacy',
+    NUMERIC_MODE_SAFE : 'safe',
+    NUMERIC_MODE_STRING : 'string',
+} as const;
+
 const op = {
     op_void                   : 0,  // Packet has been voided
     op_connect                : 1,  // Connect to remote server
@@ -929,6 +935,7 @@ const Const = Object.freeze({
     ...int,
     ...iscAction,
     ...iscError,
+    ...numericMode,
     ...op,
     ...protocol,
     ...service,

--- a/src/wire/const.ts
+++ b/src/wire/const.ts
@@ -26,7 +26,7 @@ const int = {
 };
 
 const numericMode = {
-    NUMERIC_MODE_LEGACY : 'legacy',
+    NUMERIC_MODE_LOSSY : 'lossy',
     NUMERIC_MODE_SAFE : 'safe',
     NUMERIC_MODE_STRING : 'string',
 } as const;

--- a/src/wire/serialize.ts
+++ b/src/wire/serialize.ts
@@ -481,13 +481,27 @@ export class XdrReader {
         // Note: precision is limited to Number.MAX_SAFE_INTEGER (±2^53-1).
         // Values outside this range lose precision, which matches the previous
         // Long(low, high).toNumber() behaviour.
-        const result = Number(this.buffer.readBigInt64BE(this.pos));
+        return Number(this.readInt64BigInt());
+    }
+
+    readInt64BigInt(): bigint {
+        const result = this.buffer.readBigInt64BE(this.pos);
         this.pos += 8;
         return result;
     }
 
-    readInt128() {
+    readInt128(): bigint {
         var high = this.buffer.readBigUInt64BE(this.pos)
+        this.pos += 8
+
+        var low = this.buffer.readBigUInt64BE(this.pos)
+        this.pos += 8
+
+        return (BigInt(high) << BigInt(64)) + BigInt(low)
+    }
+
+    readInt128Signed(): bigint {
+        var high = this.buffer.readBigInt64BE(this.pos)
         this.pos += 8
 
         var low = this.buffer.readBigUInt64BE(this.pos)

--- a/src/wire/xsqlvar.ts
+++ b/src/wire/xsqlvar.ts
@@ -49,8 +49,8 @@ function decodeExactNumeric(value: bigint, scale: number, mode: 'safe' | 'string
         : Number(value) * Math.pow(10, scale);
 }
 
-/** Preserve the pre-numericMode INT128 result contract in legacy mode. */
-function decodeLegacyInt128(value: bigint, scale: number): number | string {
+/** Decode INT128 using the mixed number/string policy of lossy mode. */
+function decodeLossyInt128(value: bigint, scale: number): number | string {
     if (value > MAX_SAFE_BIGINT) {
         const digits = value.toString();
         let integerPart = digits.slice(0, Math.abs(scale) * -1);
@@ -599,10 +599,10 @@ export class SQLVarShort extends SQLVarInt {
 
 export class SQLVarInt64 extends SQLVarBase {
     decode(data: XdrReader, lowerV13: boolean, options?: NumericDecodeOptions) {
-        const mode = options?.numericMode || Const.NUMERIC_MODE_LEGACY;
+        const mode = options?.numericMode || Const.NUMERIC_MODE_LOSSY;
         let ret: number | string;
 
-        if (mode === Const.NUMERIC_MODE_LEGACY) {
+        if (mode === Const.NUMERIC_MODE_LOSSY) {
             ret = data.readInt64();
             if (this.scale) ret = ret / ScaleDivisor[Math.abs(this.scale)];
         } else {
@@ -625,9 +625,9 @@ export class SQLVarInt64 extends SQLVarBase {
 
 export class SQLVarInt128 extends SQLVarBase {
     decode(data: XdrReader, lowerV13: boolean, options?: NumericDecodeOptions) {
-        const mode = options?.numericMode || Const.NUMERIC_MODE_LEGACY;
-        const ret = mode === Const.NUMERIC_MODE_LEGACY
-            ? decodeLegacyInt128(data.readInt128(), this.scale)
+        const mode = options?.numericMode || Const.NUMERIC_MODE_LOSSY;
+        const ret = mode === Const.NUMERIC_MODE_LOSSY
+            ? decodeLossyInt128(data.readInt128(), this.scale)
             : decodeExactNumeric(data.readInt128Signed(), this.scale, mode);
 
         if (!lowerV13 || !data.readInt()) {

--- a/src/wire/xsqlvar.ts
+++ b/src/wire/xsqlvar.ts
@@ -52,12 +52,7 @@ function decodeExactNumeric(value: bigint, scale: number, mode: 'safe' | 'string
 /** Decode INT128 using the mixed number/string policy of lossy mode. */
 function decodeLossyInt128(value: bigint, scale: number): number | string {
     if (value > MAX_SAFE_BIGINT) {
-        const digits = value.toString();
-        let integerPart = digits.slice(0, Math.abs(scale) * -1);
-        const decimalPart = digits.slice(Math.abs(scale) * -1);
-
-        if (integerPart === '') integerPart = '0';
-        return `${integerPart}.${decimalPart}`;
+        return formatScaledBigInt(value, scale);
     }
 
     return Number(value) / ScaleDivisor[Math.abs(scale)];

--- a/src/wire/xsqlvar.ts
+++ b/src/wire/xsqlvar.ts
@@ -3,7 +3,7 @@ import { BlrReader } from './serialize';
 import { getCodec } from './codepages';
 import type { TextCodec } from './codepages';
 import type { XdrReader, XdrWriter, BlrWriter } from './serialize';
-import type { RecordCounts } from '../types';
+import type { NumericMode, RecordCounts } from '../types';
 
 /***************************************
  *
@@ -19,6 +19,49 @@ const
     MsPerMinute = 60000;
 
 const EMPTY_BUFFER = Buffer.alloc(0);
+const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE_BIGINT = BigInt(Number.MIN_SAFE_INTEGER);
+
+type NumericDecodeOptions = {
+    numericMode?: NumericMode;
+};
+
+/** Format a signed Firebird integer coefficient without passing through Number. */
+function formatScaledBigInt(value: bigint, scale: number): string {
+    const negative = value < 0n;
+    let digits = (negative ? -value : value).toString();
+    const sign = negative ? '-' : '';
+
+    if (scale === 0) return sign + digits;
+    if (scale > 0) return sign + digits + '0'.repeat(scale);
+
+    const places = -scale;
+    if (digits.length <= places) digits = digits.padStart(places + 1, '0');
+    return sign + digits.slice(0, -places) + '.' + digits.slice(-places);
+}
+
+function decodeExactNumeric(value: bigint, scale: number, mode: 'safe' | 'string'): number | string {
+    if (mode === 'string' || value > MAX_SAFE_BIGINT || value < MIN_SAFE_BIGINT) {
+        return formatScaledBigInt(value, scale);
+    }
+    return scale < 0
+        ? Number(value) / Math.pow(10, -scale)
+        : Number(value) * Math.pow(10, scale);
+}
+
+/** Preserve the pre-numericMode INT128 result contract in legacy mode. */
+function decodeLegacyInt128(value: bigint, scale: number): number | string {
+    if (value > MAX_SAFE_BIGINT) {
+        const digits = value.toString();
+        let integerPart = digits.slice(0, Math.abs(scale) * -1);
+        const decimalPart = digits.slice(Math.abs(scale) * -1);
+
+        if (integerPart === '') integerPart = '0';
+        return `${integerPart}.${decimalPart}`;
+    }
+
+    return Number(value) / ScaleDivisor[Math.abs(scale)];
+}
 
 /**
  * Maps Firebird character-set names (upper-case) to the Node.js Buffer
@@ -555,11 +598,15 @@ export class SQLVarShort extends SQLVarInt {
 //------------------------------------------------------
 
 export class SQLVarInt64 extends SQLVarBase {
-    decode(data: XdrReader, lowerV13: boolean) {
-        var ret = data.readInt64();
+    decode(data: XdrReader, lowerV13: boolean, options?: NumericDecodeOptions) {
+        const mode = options?.numericMode || Const.NUMERIC_MODE_LEGACY;
+        let ret: number | string;
 
-        if (this.scale) {
-            ret = ret / ScaleDivisor[Math.abs(this.scale)];
+        if (mode === Const.NUMERIC_MODE_LEGACY) {
+            ret = data.readInt64();
+            if (this.scale) ret = ret / ScaleDivisor[Math.abs(this.scale)];
+        } else {
+            ret = decodeExactNumeric(data.readInt64BigInt(), this.scale, mode);
         }
 
         if (!lowerV13 || !data.readInt()) {
@@ -577,23 +624,11 @@ export class SQLVarInt64 extends SQLVarBase {
 //------------------------------------------------------
 
 export class SQLVarInt128 extends SQLVarBase {
-    decode(data: XdrReader, lowerV13: boolean) {
-        var retBigInt = BigInt(data.readInt128())
-        let ret: string | number;
-
-        if (retBigInt > BigInt(Number.MAX_SAFE_INTEGER)) {
-            ret = retBigInt.toString();
-
-            var integerPart = ret.slice(0, Math.abs(this.scale) * -1)
-            var decimalPart = ret.slice(Math.abs(this.scale) * -1)
-
-            if (integerPart === '') integerPart = '0'
-
-            ret = `${integerPart}.${decimalPart}`
-        } else {
-            ret = Number(retBigInt);
-            ret = ret / ScaleDivisor[Math.abs(this.scale)];
-        }
+    decode(data: XdrReader, lowerV13: boolean, options?: NumericDecodeOptions) {
+        const mode = options?.numericMode || Const.NUMERIC_MODE_LEGACY;
+        const ret = mode === Const.NUMERIC_MODE_LEGACY
+            ? decodeLegacyInt128(data.readInt128(), this.scale)
+            : decodeExactNumeric(data.readInt128Signed(), this.scale, mode);
 
         if (!lowerV13 || !data.readInt()) {
             return ret;

--- a/test/type-cast.js
+++ b/test/type-cast.js
@@ -27,6 +27,19 @@ describe('typeCast hook', function () {
         await db.queryAsync(
             'INSERT INTO cast_test (id, name, big, price, born, note) VALUES (?, ?, ?, ?, ?, ?)',
             [2, 'bob', 42, null, null, null]);
+        await db.queryAsync(
+            'CREATE TABLE numeric_mode_test (id INT NOT NULL PRIMARY KEY, ' +
+            'amount DECIMAL(15,4), raw_big BIGINT)');
+        await db.queryAsync(
+            'INSERT INTO numeric_mode_test VALUES (1, 900719925474.0991, 9007199254740991)');
+        await db.queryAsync(
+            'INSERT INTO numeric_mode_test VALUES (2, 900719925474.0992, 9007199254740992)');
+        await db.queryAsync(
+            'INSERT INTO numeric_mode_test VALUES (3, 900719925474.0993, 9223372036854775807)');
+        await db.queryAsync(
+            'INSERT INTO numeric_mode_test VALUES (4, -900719925474.0993, -9223372036854775808)');
+        await db.queryAsync(
+            'INSERT INTO numeric_mode_test VALUES (5, 42.0000, 42)');
     });
 
     afterAll(async function () {
@@ -70,6 +83,45 @@ describe('typeCast hook', function () {
         assert.strictEqual(rows[0].big, '123456789012345');
         assert.strictEqual(typeof rows[1].big, 'string');
         assert.strictEqual(rows[0].name, 'alice'); // untouched
+    });
+
+    it('safe numeric mode preserves unsafe INT64-backed values exactly', async function () {
+        const safeDb = await Firebird.attachAsync(Config.extends(config, {
+            numericMode: Firebird.NUMERIC_MODE_SAFE,
+        }));
+        try {
+            const rows = await safeDb.queryAsync(
+                'SELECT id, amount, raw_big, CAST(amount AS VARCHAR(40)) expected_amount, ' +
+                'CAST(raw_big AS VARCHAR(40)) expected_big FROM numeric_mode_test ORDER BY id');
+
+            assert.strictEqual(rows[0].amount, 900719925474.0991);
+            assert.strictEqual(rows[0].raw_big, 9007199254740991);
+            for (const row of rows.slice(1, 4)) {
+                assert.strictEqual(row.amount, row.expected_amount.trim());
+                assert.strictEqual(row.raw_big, row.expected_big.trim());
+            }
+            assert.strictEqual(rows[4].amount, 42);
+            assert.strictEqual(rows[4].raw_big, 42);
+        } finally {
+            await safeDb.detachAsync();
+        }
+    });
+
+    it('string numeric mode gives INT64-backed columns a stable exact type', async function () {
+        const stringDb = await Firebird.attachAsync(Config.extends(config, {
+            numericMode: Firebird.NUMERIC_MODE_STRING,
+        }));
+        try {
+            const rows = await stringDb.queryAsync(
+                'SELECT amount, raw_big FROM numeric_mode_test ORDER BY id');
+            assert.deepStrictEqual(rows[0], {
+                amount: '900719925474.0991',
+                raw_big: '9007199254740991',
+            });
+            assert.deepStrictEqual(rows[4], { amount: '42.0000', raw_big: '42' });
+        } finally {
+            await stringDb.detachAsync();
+        }
     });
 
     it('casts DATE columns to strings', async function () {

--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -26,7 +26,7 @@ describe('public API surface', () => {
     });
 
     it('exports numeric result modes', () => {
-        expect(Firebird.NUMERIC_MODE_LEGACY).toBe('legacy');
+        expect(Firebird.NUMERIC_MODE_LOSSY).toBe('lossy');
         expect(Firebird.NUMERIC_MODE_SAFE).toBe('safe');
         expect(Firebird.NUMERIC_MODE_STRING).toBe('string');
 

--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -25,6 +25,15 @@ describe('public API surface', () => {
         expect(Firebird.WIRE_CRYPT_ENABLE).toBe(1);
     });
 
+    it('exports numeric result modes', () => {
+        expect(Firebird.NUMERIC_MODE_LEGACY).toBe('legacy');
+        expect(Firebird.NUMERIC_MODE_SAFE).toBe('safe');
+        expect(Firebird.NUMERIC_MODE_STRING).toBe('string');
+
+        const options: Firebird.Options = { numericMode: Firebird.NUMERIC_MODE_SAFE };
+        expect(options.numericMode).toBe('safe');
+    });
+
     it('exports isolation level arrays', () => {
         for (const iso of [
             Firebird.ISOLATION_READ_UNCOMMITTED,

--- a/test/unit/env-defaults.test.ts
+++ b/test/unit/env-defaults.test.ts
@@ -87,6 +87,7 @@ describe('environment-variable connection defaults', () => {
     });
 
     it('accepts numericMode from objects and connection URIs', () => {
+        expect(normalizeOptions<any>({ numericMode: 'lossy' }).numericMode).toBe('lossy');
         expect(normalizeOptions<any>({ numericMode: 'safe' }).numericMode).toBe('safe');
         expect(normalizeOptions<any>('firebird://localhost/x.fdb?numericMode=string').numericMode)
             .toBe('string');
@@ -94,6 +95,8 @@ describe('environment-variable connection defaults', () => {
 
     it('rejects an unknown numericMode', () => {
         expect(() => normalizeOptions<any>({ numericMode: 'precise' }))
+            .toThrow(/Invalid numericMode option/);
+        expect(() => normalizeOptions<any>({ numericMode: 'legacy' }))
             .toThrow(/Invalid numericMode option/);
     });
 });

--- a/test/unit/env-defaults.test.ts
+++ b/test/unit/env-defaults.test.ts
@@ -85,4 +85,15 @@ describe('environment-variable connection defaults', () => {
         expect(out.database).toBeUndefined();
         expect(out.user).toBe('ENVUSER'); // credentials still apply
     });
+
+    it('accepts numericMode from objects and connection URIs', () => {
+        expect(normalizeOptions<any>({ numericMode: 'safe' }).numericMode).toBe('safe');
+        expect(normalizeOptions<any>('firebird://localhost/x.fdb?numericMode=string').numericMode)
+            .toBe('string');
+    });
+
+    it('rejects an unknown numericMode', () => {
+        expect(() => normalizeOptions<any>({ numericMode: 'precise' }))
+            .toThrow(/Invalid numericMode option/);
+    });
 });

--- a/test/unit/serialize.test.ts
+++ b/test/unit/serialize.test.ts
@@ -117,11 +117,36 @@ describe('XdrWriter / XdrReader round-trips', () => {
         expect(r.readInt64()).toBe(-1);
     });
 
+    it('readInt64BigInt preserves the full signed range', () => {
+        const w = new XdrWriter();
+        w.addInt64(-9223372036854775808n);
+        w.addInt64(9223372036854775807n);
+        const r = new XdrReader(w.getData());
+        expect(r.readInt64BigInt()).toBe(-9223372036854775808n);
+        expect(r.readInt64BigInt()).toBe(9223372036854775807n);
+    });
+
     it('int128 preserves bigint precision', () => {
         const big = 123456789012345678901234567890n;
         const w = new XdrWriter();
         w.addInt128(big);
         expect(new XdrReader(w.getData()).readInt128()).toBe(big);
+    });
+
+    it('readInt128Signed preserves signed extrema', () => {
+        const min = -(1n << 127n);
+        const max = (1n << 127n) - 1n;
+        const values = [min, -1n, max];
+        const buffer = Buffer.alloc(values.length * 16);
+        values.forEach((value, index) => {
+            const offset = index * 16;
+            buffer.writeBigInt64BE(value >> 64n, offset);
+            buffer.writeBigUInt64BE(value & 0xFFFFFFFFFFFFFFFFn, offset + 8);
+        });
+        const r = new XdrReader(buffer);
+        expect(r.readInt128Signed()).toBe(min);
+        expect(r.readInt128Signed()).toBe(-1n);
+        expect(r.readInt128Signed()).toBe(max);
     });
 
     it('readArray recovers Firebird 2.5 sign-extended lengths (issue #312)', () => {

--- a/test/unit/xsqlvar.test.ts
+++ b/test/unit/xsqlvar.test.ts
@@ -9,6 +9,13 @@ function reader(write: (w: XdrWriter) => void): XdrReader {
     return new XdrReader(w.getData());
 }
 
+function signedInt128Reader(value: bigint): XdrReader {
+    const buffer = Buffer.alloc(16);
+    buffer.writeBigInt64BE(value >> 64n, 0);
+    buffer.writeBigUInt64BE(value & 0xFFFFFFFFFFFFFFFFn, 8);
+    return new XdrReader(buffer);
+}
+
 describe('SQLVar decoding (protocol 13+, lowerV13=false)', () => {
     it('SQLVarInt applies negative scale as a divisor', () => {
         const v = new Xsql.SQLVarInt();
@@ -28,6 +35,44 @@ describe('SQLVar decoding (protocol 13+, lowerV13=false)', () => {
         expect(v.decode(reader(w => w.addInt64(1234567)), false)).toBe(1234.567);
     });
 
+    it('legacy mode remains the default for unsafe INT64 values', () => {
+        const v = new Xsql.SQLVarInt64();
+        v.scale = -4;
+        expect(v.decode(reader(w => w.addInt64(9007199254740993n)), false))
+            .toBe(900719925474.0992);
+        expect(v.decode(reader(w => w.addInt64(9007199254740993n)), false,
+            { numericMode: 'legacy' })).toBe(900719925474.0992);
+    });
+
+    it.each([
+        [-9007199254740992n, 0, '-9007199254740992'],
+        [-9007199254740991n, 0, -9007199254740991],
+        [9007199254740991n, 0, 9007199254740991],
+        [9007199254740992n, 0, '9007199254740992'],
+        [-9223372036854775808n, -4, '-922337203685477.5808'],
+        [9223372036854775807n, -4, '922337203685477.5807'],
+        [9007199254740992n, -2, '90071992547409.92'],
+        [-9007199254741000n, -4, '-900719925474.1000'],
+    ])('safe mode preserves INT64 coefficient %s at scale %s', (coefficient, scale, expected) => {
+        const v = new Xsql.SQLVarInt64();
+        v.scale = scale;
+        expect(v.decode(reader(w => w.addInt64(coefficient)), false, { numericMode: 'safe' }))
+            .toBe(expected);
+    });
+
+    it('string mode returns safe INT64 values as scale-preserving strings', () => {
+        const v = new Xsql.SQLVarInt64();
+        v.scale = -4;
+        expect(v.decode(reader(w => w.addInt64(420000n)), false, { numericMode: 'string' }))
+            .toBe('42.0000');
+        expect(v.decode(reader(w => w.addInt64(0n)), false, { numericMode: 'string' }))
+            .toBe('0.0000');
+
+        v.scale = 0;
+        expect(v.decode(reader(w => w.addInt64(42n)), false, { numericMode: 'string' }))
+            .toBe('42');
+    });
+
     it('SQLVarInt128 returns a decimal string for values beyond MAX_SAFE_INTEGER', () => {
         const v = new Xsql.SQLVarInt128();
         v.scale = -2;
@@ -39,6 +84,33 @@ describe('SQLVar decoding (protocol 13+, lowerV13=false)', () => {
         const v = new Xsql.SQLVarInt128();
         v.scale = -2;
         expect(v.decode(reader(w => w.addInt128(12345n)), false)).toBe(123.45);
+    });
+
+    it('safe mode formats signed INT128 values exactly', () => {
+        const v = new Xsql.SQLVarInt128();
+        v.scale = -4;
+        expect(v.decode(signedInt128Reader(-123456789012345678901n), false,
+            { numericMode: 'safe' })).toBe('-12345678901234567.8901');
+
+        v.scale = 0;
+        expect(v.decode(signedInt128Reader(-(1n << 127n)), false,
+            { numericMode: 'safe' })).toBe('-170141183460469231731687303715884105728');
+        expect(v.decode(reader(w => w.addInt128((1n << 127n) - 1n)), false,
+            { numericMode: 'safe' })).toBe('170141183460469231731687303715884105727');
+    });
+
+    it('string mode returns safe INT128 values as strings', () => {
+        const v = new Xsql.SQLVarInt128();
+        v.scale = -4;
+        expect(v.decode(signedInt128Reader(-42n), false, { numericMode: 'string' }))
+            .toBe('-0.0042');
+    });
+
+    it('numeric modes preserve null indicators', () => {
+        const v = new Xsql.SQLVarInt64();
+        v.scale = 0;
+        expect(v.decode(reader(w => { w.addInt64(9223372036854775807n); w.addInt(1); }), true,
+            { numericMode: 'safe' })).toBeNull();
     });
 
     it('SQLVarBoolean decodes to true/false', () => {

--- a/test/unit/xsqlvar.test.ts
+++ b/test/unit/xsqlvar.test.ts
@@ -80,6 +80,23 @@ describe('SQLVar decoding (protocol 13+, lowerV13=false)', () => {
         expect(v.decode(reader(w => w.addInt128(big)), false)).toBe('1234567890123456789.01');
     });
 
+    it('lossy mode formats unsafe positive INT128 values for every scale shape', () => {
+        const v = new Xsql.SQLVarInt128();
+        const coefficient = 9007199254740992n;
+
+        v.scale = 0;
+        expect(v.decode(reader(w => w.addInt128(coefficient)), false))
+            .toBe('9007199254740992');
+
+        v.scale = -20;
+        expect(v.decode(reader(w => w.addInt128(coefficient)), false,
+            { numericMode: 'lossy' })).toBe('0.00009007199254740992');
+
+        v.scale = 2;
+        expect(v.decode(reader(w => w.addInt128(coefficient)), false,
+            { numericMode: 'lossy' })).toBe('900719925474099200');
+    });
+
     it('SQLVarInt128 returns a number for small values', () => {
         const v = new Xsql.SQLVarInt128();
         v.scale = -2;

--- a/test/unit/xsqlvar.test.ts
+++ b/test/unit/xsqlvar.test.ts
@@ -35,13 +35,13 @@ describe('SQLVar decoding (protocol 13+, lowerV13=false)', () => {
         expect(v.decode(reader(w => w.addInt64(1234567)), false)).toBe(1234.567);
     });
 
-    it('legacy mode remains the default for unsafe INT64 values', () => {
+    it('lossy mode remains the default for unsafe INT64 values', () => {
         const v = new Xsql.SQLVarInt64();
         v.scale = -4;
         expect(v.decode(reader(w => w.addInt64(9007199254740993n)), false))
             .toBe(900719925474.0992);
         expect(v.decode(reader(w => w.addInt64(9007199254740993n)), false,
-            { numericMode: 'legacy' })).toBe(900719925474.0992);
+            { numericMode: 'lossy' })).toBe(900719925474.0992);
     });
 
     it.each([


### PR DESCRIPTION
## Summary

Adds an opt-in `numericMode` connection option for exact `BIGINT`, `INT128`, and integer-backed `NUMERIC`/`DECIMAL` query results.

The three modes are:

- `NUMERIC_MODE_LOSSY` (default): INT64-backed values are returned as numbers; INT128 uses a mixed number/string path. Unsafe coefficients may lose precision.
- `NUMERIC_MODE_SAFE`: returns a number when the raw integer coefficient is within JavaScript's safe integer range, otherwise an exact scaled string.
- `NUMERIC_MODE_STRING`: always returns an exact, scale-preserving string.

The string values `lossy`, `safe`, and `string` are also accepted, including in connection URIs.

## Motivation

Firebird represents these fixed-point values on the wire as an integer coefficient plus a scale. Converting an unsafe coefficient to a JavaScript `number` loses digits before an application-level `typeCast` hook can turn it into a string.

Making exact decoding the default would change result types for existing applications. This PR therefore keeps the current decoding policy as the default `LOSSY` mode and makes exact handling explicit, allowing applications to choose either a mixed `number | string` contract or a stable string contract.

## Implementation

- Exports the three numeric-mode constants and a `NumericMode` TypeScript type.
- Validates `options.numericMode` for object and URI-based connections.
- Decodes INT64 and signed two's-complement INT128 coefficients exactly in the opt-in modes.
- Uses the raw coefficient, before scaling, for the safe-range decision.
- Formats exact strings without passing through `Number`, preserving sign, leading fractional zeroes, and scale-implied trailing zeroes.
- Leaves `NULL`, `FLOAT`, `DOUBLE`, `DECFLOAT`, and input-parameter encoding unchanged.
- Documents why `String(next())` in `typeCast` cannot recover precision already lost in lossy decoding.

## Compatibility

`NUMERIC_MODE_LOSSY` remains the default so that adding `numericMode` does not silently change result types for applications upgrading from earlier node-firebird releases. For coefficients outside JavaScript's safe integer range, numeric precision is not guaranteed in this mode.

## Test coverage

Tests cover:

- Safe boundaries and immediately unsafe INT64 coefficients.
- INT64 minimum and maximum values.
- Scales `0`, `-2`, and `-4`, including negative values and trailing zeroes.
- Signed INT128 extrema and two's-complement decoding.
- `SAFE`, `STRING`, and default `LOSSY` behavior.
- Object and connection-URI configuration.
- `NULL` handling and the public TypeScript/API surface.
- Firebird 3 integration with `BIGINT` and `DECIMAL(15,4)`, independently checked against server-side string casts.

Validated with Node.js 20 and 24 using build, typecheck, lint, offline unit tests, and the Firebird 3 integration suite.
