### PR TITLE
fix(pool): preserve connection lifecycle during destroy

### DIFF
--- a/src/pool.ts
+++ b/src/pool.ts
@@ -281,6 +281,11 @@ class Pool extends Events.EventEmitter {
                         if (db.connection._isClosed || db.connection._isDetach || db.connection._pooled === false) {
                             self.internaldb.splice(self.internaldb.indexOf(db), 1);
                             self.emit('remove', db);
+                        } else if (self._destroyed) {
+                            // destroy() deliberately does not wait for checked-out
+                            // connections. Close one for good when its caller later
+                            // releases it instead of returning it to a stopped pool.
+                            self._retire(db);
                         } else if (self._isExpired(db)) {
                             // worn out (maxUses / maxLifetimeMillis): close it
                             // for good instead of returning it to the idle
@@ -363,7 +368,8 @@ class Pool extends Events.EventEmitter {
             } else {
                 // [Fix 5] Connection is currently in use (dbinuse > 0).
                 // The caller is responsible for releasing it via detach().
-                // Count it down here so the destroy() callback is not blocked forever.
+                // Count it down here so the destroy() callback is not blocked forever;
+                // the detach listener retires it when the caller releases it.
                 detachCallback();
             }
         });

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -353,7 +353,7 @@ class Pool extends Events.EventEmitter {
             }
         }
 
-        this.internaldb.forEach(function(db) {
+        this.internaldb.slice().forEach(function(db) {
             if (db.connection._pooled === false) {
                 detachCallback();
                 return;
@@ -361,10 +361,14 @@ class Pool extends Events.EventEmitter {
             // check if the db is not free into the pool otherwise user should manual detach it
             var _db_in_pool = self.pooldb.indexOf(db);
             if (_db_in_pool !== -1) {
-                self.pooldb.splice(_db_in_pool, 1);
                 db.connection._pooled = false;
-                db.detach(detachCallback);
-                self.emit('remove', db);
+                // Keep the connection marked idle until physical detach emits
+                // its detach event. The listener above will then ignore that
+                // event instead of counting it as an active release.
+                db.detach(function(err?: any) {
+                    self._forget(db);
+                    detachCallback(err);
+                });
             } else {
                 // [Fix 5] Connection is currently in use (dbinuse > 0).
                 // The caller is responsible for releasing it via detach().

--- a/test/pool-observability.js
+++ b/test/pool-observability.js
@@ -60,8 +60,11 @@ describe('Pool observability (events + metrics)', function () {
             await pool.destroyAsync();
         }
         // destroy closes the idle physical connection
-        assert.ok(events.includes('remove'));
+        assert.strictEqual(events.filter((event) => event === 'remove').length, 1);
+        assert.strictEqual(pool.totalCount, 0);
         assert.strictEqual(pool.idleCount, 0);
+        assert.strictEqual(pool.activeCount, 0);
+        assert.strictEqual(pool.waitingCount, 0);
     });
 
     it('should count callers waiting for a slot', async function () {

--- a/test/unit/pool.test.ts
+++ b/test/unit/pool.test.ts
@@ -117,6 +117,36 @@ describe('Pool', () => {
         expect(detachSpy).toHaveBeenCalled();
     });
 
+    it('retires an active connection when it is released after destroy()', async () => {
+        const { attach } = makeFakeAttach();
+        const pool = new Pool(attach, 1, {});
+        const db = await poolGet(pool);
+        const detachSpy = vi.spyOn(db, 'detach');
+        const removeSpy = vi.fn();
+        const releaseSpy = vi.fn();
+        pool.on('remove', removeSpy);
+        pool.on('release', releaseSpy);
+
+        await new Promise<void>((resolve, reject) =>
+            pool.destroy(err => (err ? reject(err) : resolve())));
+
+        expect(pool.activeCount).toBe(1);
+        expect(pool.totalCount).toBe(1);
+        expect(detachSpy).not.toHaveBeenCalled();
+
+        db.detach();
+
+        // The first call is the caller's release. _retire() makes the second
+        // call with _pooled=false, which is a physical detach in a real db.
+        expect(detachSpy).toHaveBeenCalledTimes(2);
+        expect(db.connection._pooled).toBe(false);
+        expect(pool.activeCount).toBe(0);
+        expect(pool.idleCount).toBe(0);
+        expect(pool.totalCount).toBe(0);
+        expect(removeSpy).toHaveBeenCalledTimes(1);
+        expect(releaseSpy).not.toHaveBeenCalled();
+    });
+
     it('times out attach() when connectTimeout expires', async () => {
         const { attach } = makeFakeAttach({ neverCallback: true });
         const pool = new Pool(attach, 1, { connectTimeout: 40 });

--- a/test/unit/pool.test.ts
+++ b/test/unit/pool.test.ts
@@ -107,14 +107,29 @@ describe('Pool', () => {
         const { attach } = makeFakeAttach();
         const pool = new Pool(attach, 2, {});
         const db1 = await poolGet(pool);
-        const detachSpy = vi.spyOn(db1, 'detach');
+        const db2 = await poolGet(pool);
         db1.detach(); // return to pool
-        detachSpy.mockClear();
+        db2.detach();
         await new Promise(setImmediate);
+        const detachSpy1 = vi.spyOn(db1, 'detach');
+        const detachSpy2 = vi.spyOn(db2, 'detach');
+        const removeSpy = vi.fn();
+        pool.on('remove', removeSpy);
+
+        expect(pool.activeCount).toBe(0);
+        expect(pool.idleCount).toBe(2);
+        expect(pool.totalCount).toBe(2);
 
         await new Promise<void>((resolve, reject) =>
             pool.destroy(err => (err ? reject(err) : resolve())));
-        expect(detachSpy).toHaveBeenCalled();
+
+        expect(detachSpy1).toHaveBeenCalledTimes(1);
+        expect(detachSpy2).toHaveBeenCalledTimes(1);
+        expect(pool.activeCount).toBe(0);
+        expect(pool.idleCount).toBe(0);
+        expect(pool.totalCount).toBe(0);
+        expect(pool.waitingCount).toBe(0);
+        expect(removeSpy).toHaveBeenCalledTimes(2);
     });
 
     it('retires an active connection when it is released after destroy()', async () => {


### PR DESCRIPTION
## Summary

Fixes two related pool shutdown lifecycle issues:

- Checked-out connections released after `pool.destroy()` are retired instead of being returned to the destroyed pool.
- Idle connections remain correctly classified while being detached, preventing `activeCount` from becoming negative and preserving accurate removal events.

## Motivation

`pool.destroy()` intentionally completes without waiting for checked-out connections. Previously, when one of those connections was released later, its normal detach path could return it to a pool that had already been stopped.

There was also an accounting issue for idle connections. During destruction they were removed from the idle collection before physical detach completed. The detach listener could consequently interpret them as active connections and decrement the active count, producing negative diagnostics.

## Implementation

- Retire a checked-out pooled connection when it is released after pool destruction.
- Iterate over a snapshot of idle connections during destruction.
- Keep each idle connection classified as idle until its physical detach completes, then forget it exactly once.
- Preserve the current non-blocking contract: `destroy()` does not wait for callers that still hold checked-out connections.
- Introduce no public API changes and no automatic drain/wait behavior.

## Test coverage

- A checked-out connection retained across `destroy()` is physically detached when later released; all metrics reach zero, exactly one `remove` event is emitted, and no `release` event is emitted.
- Destroying two idle connections detaches each exactly once, emits exactly two `remove` events, and leaves all metrics at zero.
- The pool observability integration test verifies exact removal events and zero final metrics.

Validation completed with:

```text
npm ci
npm run build
npm run typecheck
npm run lint
npx vitest run test/unit/pool.test.ts test/pool-observability.js test/pool.js test/pool-fixes.js
npx vitest run --exclude test/service.js
npx vitest run test/service.js
npm pack --dry-run
git diff --check
```

Results: 25 focused pool tests passed; 712 main-suite tests passed with 34 skipped; 34 service tests passed with 6 skipped and 1 todo.
