### PR TITLE
fix(batch): preserve scaled numeric parameter precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1908,10 +1908,14 @@ in bytes).
 Notes:
 
 - Requires wire protocol 16+ (Firebird 4.0 or newer server).
-- Values are encoded from the statement's own parameter metadata, so
-  NUMERIC/DECIMAL scale, `BIGINT`/`INT128` (pass `BigInt`), `BOOLEAN`,
-  `TIMESTAMP`/`DATE`/`TIME`, `FLOAT`/`DOUBLE` and `DECFLOAT` all round-trip
-  exactly.
+- Values are encoded from the statement's own parameter metadata. Fixed-point
+  `NUMERIC`/`DECIMAL`, `BIGINT`, and `INT128` parameters accept numbers, decimal
+  strings, and `BigInt`. Decimal strings retain their exact digits; finite
+  numbers are interpreted through their canonical decimal representation and
+  rounded to the declared scale with ties away from zero. Use a string (or
+  `BigInt` for whole values) when the input is outside JavaScript's safe integer
+  range. `BOOLEAN`, `TIMESTAMP`/`DATE`/`TIME`, `FLOAT`/`DOUBLE`, and `DECFLOAT`
+  use their corresponding wire types.
 - `BLOB` columns accept Buffers, strings, JSON-able objects, or
   pre-created blob quad ids: values are uploaded as transaction blobs
   first — all initiated back-to-back so the blob ops pipeline on the

--- a/src/wire/connection.ts
+++ b/src/wire/connection.ts
@@ -3573,15 +3573,14 @@ function buildBatchEncoders(input: any[], options: any) {
         if (typeof v === 'string') return parseDate(v);
         return new Date(v);
     };
-    var scaled = function(v: any, scale: number): number {
-        var n = typeof v === 'string' ? parseFloat(v) : Number(v);
-        return scale ? Math.round(n * Math.pow(10, -scale)) : n;
-    };
-    var scaledBig = function(v: any, scale: number): bigint {
-        if (typeof v === 'bigint') {
-            return scale ? v * (10n ** BigInt(-scale)) : v;
+    var scaled = function(v: any, meta: any, bits: 16 | 32 | 64 | 128, column: number): bigint {
+        try {
+            return Xsql.toScaledInteger(v, meta.scale, bits);
+        } catch (err) {
+            var message = err instanceof Error ? err.message : String(err);
+            throw new Error('Invalid fixed-point batch value for column ' + column +
+                ' (' + (meta.field || '?') + '): ' + message);
         }
-        return BigInt(scaled(v, scale));
     };
 
     for (var j = 0; j < input.length; j++) {
@@ -3616,32 +3615,32 @@ function buildBatchEncoders(input: any[], options: any) {
 
             case Const.SQL_SHORT:
                 // 2 bytes in the message struct (msglen), 4 on the XDR wire
-                encoders.push((function(m) {
-                    return function(msg: any, v: any) { msg.addInt(scaled(v, m.scale)); };
-                })(meta));
+                encoders.push((function(m, col) {
+                    return function(msg: any, v: any) { msg.addInt(Number(scaled(v, m, 16, col))); };
+                })(meta, column));
                 align(2); offset += 2;
                 break;
 
             case Const.SQL_LONG:
-                encoders.push((function(m) {
-                    return function(msg: any, v: any) { msg.addInt(scaled(v, m.scale)); };
-                })(meta));
+                encoders.push((function(m, col) {
+                    return function(msg: any, v: any) { msg.addInt(Number(scaled(v, m, 32, col))); };
+                })(meta, column));
                 align(4); offset += 4;
                 break;
 
             case Const.SQL_INT64:
-                encoders.push((function(m) {
+                encoders.push((function(m, col) {
                     return function(msg: any, v: any) {
-                        msg.addInt64(typeof v === 'bigint' ? (scaledBig(v, m.scale) as any) : scaled(v, m.scale));
+                        msg.addInt64(scaled(v, m, 64, col));
                     };
-                })(meta));
+                })(meta, column));
                 align(8); offset += 8;
                 break;
 
             case Const.SQL_INT128:
-                encoders.push((function(m) {
-                    return function(msg: any, v: any) { msg.addInt128(scaledBig(v, m.scale)); };
-                })(meta));
+                encoders.push((function(m, col) {
+                    return function(msg: any, v: any) { msg.addInt128(scaled(v, m, 128, col)); };
+                })(meta, column));
                 align(8); offset += 16;
                 break;
 

--- a/src/wire/connection.ts
+++ b/src/wire/connection.ts
@@ -1454,6 +1454,17 @@ class Connection {
             }
         }
 
+        // Validate fixed-point values before the BLOB pre-pass. Blob uploads
+        // write immediately, so deferring numeric validation until message
+        // encoding could leave transaction blob state behind for a batch that
+        // can never be sent.
+        try {
+            validateBatchFixedPointRows(input, rows as any[][]);
+        } catch (err) {
+            doError(err, callback);
+            return;
+        }
+
         var self = this;
 
         // BLOB pre-pass: upload every Buffer/string blob value as a
@@ -3538,6 +3549,39 @@ function scaleOutputLengths(output: any[], options: any) {
     }
 }
 
+function scaleBatchFixedPoint(value: any, meta: any, bits: 16 | 32 | 64 | 128, column: number): bigint {
+    try {
+        return Xsql.toScaledInteger(value, meta.scale, bits);
+    } catch (err) {
+        var message = err instanceof Error ? err.message : String(err);
+        throw new Error('Invalid fixed-point batch value for column ' + column +
+            ' (' + (meta.field || '?') + '): ' + message);
+    }
+}
+
+/** Validate values whose batch wire representation is metadata-directed.
+ * This runs before BLOB uploads, which may write to the transaction as soon
+ * as executeBatch starts its asynchronous pre-pass. */
+function validateBatchFixedPointRows(input: any[], rows: any[][]): void {
+    for (var i = 0; i < rows.length; i++) {
+        for (var j = 0; j < input.length; j++) {
+            var value = rows[i][j];
+            if (value === null || value === undefined) continue;
+
+            var bits: 16 | 32 | 64 | 128 | undefined;
+            switch (input[j].type) {
+                case Const.SQL_SHORT: bits = 16; break;
+                case Const.SQL_LONG: bits = 32; break;
+                case Const.SQL_INT64: bits = 64; break;
+                case Const.SQL_INT128: bits = 128; break;
+            }
+            if (bits !== undefined) {
+                scaleBatchFixedPoint(value, input[j], bits, j + 1);
+            }
+        }
+    }
+}
+
 /**
  * Batch support: the engine requires every batch message to use EXACTLY the
  * statement's described input format (unlike op_execute, where the client
@@ -3573,16 +3617,6 @@ function buildBatchEncoders(input: any[], options: any) {
         if (typeof v === 'string') return parseDate(v);
         return new Date(v);
     };
-    var scaled = function(v: any, meta: any, bits: 16 | 32 | 64 | 128, column: number): bigint {
-        try {
-            return Xsql.toScaledInteger(v, meta.scale, bits);
-        } catch (err) {
-            var message = err instanceof Error ? err.message : String(err);
-            throw new Error('Invalid fixed-point batch value for column ' + column +
-                ' (' + (meta.field || '?') + '): ' + message);
-        }
-    };
-
     for (var j = 0; j < input.length; j++) {
         var meta = input[j];
         var column = j + 1;
@@ -3616,14 +3650,14 @@ function buildBatchEncoders(input: any[], options: any) {
             case Const.SQL_SHORT:
                 // 2 bytes in the message struct (msglen), 4 on the XDR wire
                 encoders.push((function(m, col) {
-                    return function(msg: any, v: any) { msg.addInt(Number(scaled(v, m, 16, col))); };
+                    return function(msg: any, v: any) { msg.addInt(Number(scaleBatchFixedPoint(v, m, 16, col))); };
                 })(meta, column));
                 align(2); offset += 2;
                 break;
 
             case Const.SQL_LONG:
                 encoders.push((function(m, col) {
-                    return function(msg: any, v: any) { msg.addInt(Number(scaled(v, m, 32, col))); };
+                    return function(msg: any, v: any) { msg.addInt(Number(scaleBatchFixedPoint(v, m, 32, col))); };
                 })(meta, column));
                 align(4); offset += 4;
                 break;
@@ -3631,7 +3665,7 @@ function buildBatchEncoders(input: any[], options: any) {
             case Const.SQL_INT64:
                 encoders.push((function(m, col) {
                     return function(msg: any, v: any) {
-                        msg.addInt64(scaled(v, m, 64, col));
+                        msg.addInt64(scaleBatchFixedPoint(v, m, 64, col));
                     };
                 })(meta, column));
                 align(8); offset += 8;
@@ -3639,7 +3673,7 @@ function buildBatchEncoders(input: any[], options: any) {
 
             case Const.SQL_INT128:
                 encoders.push((function(m, col) {
-                    return function(msg: any, v: any) { msg.addInt128(scaled(v, m, 128, col)); };
+                    return function(msg: any, v: any) { msg.addInt128(scaleBatchFixedPoint(v, m, 128, col)); };
                 })(meta, column));
                 align(8); offset += 16;
                 break;

--- a/src/wire/connection.ts
+++ b/src/wire/connection.ts
@@ -3568,7 +3568,7 @@ function validateBatchFixedPointRows(input: any[], rows: any[][]): void {
             var value = rows[i][j];
             if (value === null || value === undefined) continue;
 
-            var bits: 16 | 32 | 64 | 128 | undefined;
+            var bits: 16 | 32 | 64 | 128 | undefined = undefined;
             switch (input[j].type) {
                 case Const.SQL_SHORT: bits = 16; break;
                 case Const.SQL_LONG: bits = 32; break;

--- a/src/wire/serialize.ts
+++ b/src/wire/serialize.ts
@@ -303,7 +303,7 @@ export class XdrWriter {
         const high = bigValue >> BigInt(64);
         const low = bigValue & BigInt("0xFFFFFFFFFFFFFFFF");
 
-        this.buffer.writeBigUInt64BE(high, this.pos);
+        this.buffer.writeBigInt64BE(high, this.pos);
         this.pos += 8;
         this.buffer.writeBigUInt64BE(low, this.pos);
         this.pos += 8;

--- a/src/wire/xsqlvar.ts
+++ b/src/wire/xsqlvar.ts
@@ -957,6 +957,83 @@ export class SQLParamInt128 {
 
 //------------------------------------------------------
 
+const FIXED_POINT_RE = /^([+-]?)(?:(\d+)(?:\.(\d*))?|\.(\d+))(?:[eE]([+-]?\d+))?$/;
+
+/**
+ * Convert a decimal input to the signed integer coefficient used by a
+ * Firebird fixed-point wire type. Numbers are interpreted through their
+ * canonical decimal string; strings and bigints never pass through Number.
+ * Digits discarded by the target scale are rounded to nearest, ties away
+ * from zero, matching Firebird's conversion of decimal parameter text.
+ */
+export function toScaledInteger(value: number | string | bigint, scale: number, bits: 16 | 32 | 64 | 128): bigint {
+    if (!Number.isSafeInteger(scale)) {
+        throw new TypeError('Fixed-point scale must be an integer');
+    }
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+        throw new TypeError('Fixed-point value must be finite');
+    }
+    if (typeof value !== 'number' && typeof value !== 'string' && typeof value !== 'bigint') {
+        throw new TypeError('Fixed-point value must be a number, string, or bigint');
+    }
+
+    const text = String(value).trim();
+    const match = FIXED_POINT_RE.exec(text);
+    if (!match) {
+        throw new TypeError('Invalid fixed-point value: ' + text);
+    }
+
+    const negative = match[1] === '-';
+    const integer = match[2] || '0';
+    const fraction = match[3] !== undefined ? match[3] : (match[4] || '');
+    const exponent = match[5] === undefined ? 0 : Number(match[5]);
+    if (!Number.isSafeInteger(exponent)) {
+        throw new RangeError('Fixed-point exponent is outside the supported range: ' + match[5]);
+    }
+
+    let digits = (integer + fraction).replace(/^0+/, '') || '0';
+    if (digits === '0') return 0n;
+
+    const shift = exponent - fraction.length - scale;
+    let coefficientDigits: string;
+    let roundUp = false;
+
+    if (shift >= 0) {
+        // Every supported destination is at most 39 decimal digits. Avoid
+        // constructing an arbitrarily large BigInt for inputs such as 1e999999.
+        if (digits.length + shift > 40) {
+            throw new RangeError('Fixed-point value is outside the signed ' + bits + '-bit range: ' + text);
+        }
+        coefficientDigits = digits + '0'.repeat(shift);
+    } else {
+        const discarded = -shift;
+        if (discarded < digits.length) {
+            const split = digits.length - discarded;
+            coefficientDigits = digits.slice(0, split);
+            roundUp = digits.charCodeAt(split) >= 0x35;
+        } else {
+            coefficientDigits = '0';
+            // If discarded exceeds the number of significant digits, the
+            // magnitude is below 0.1 coefficient and cannot round to one.
+            roundUp = discarded === digits.length && digits.charCodeAt(0) >= 0x35;
+        }
+    }
+
+    let coefficient = BigInt(coefficientDigits);
+    if (roundUp) coefficient += 1n;
+    if (negative) coefficient = -coefficient;
+
+    const width = BigInt(bits);
+    const min = -(1n << (width - 1n));
+    const max = (1n << (width - 1n)) - 1n;
+    if (coefficient < min || coefficient > max) {
+        throw new RangeError('Fixed-point value is outside the signed ' + bits + '-bit range: ' + text);
+    }
+    return coefficient;
+}
+
+//------------------------------------------------------
+
 export class SQLParamDecFloat16 {
     value: any;
 

--- a/src/wire/xsqlvar.ts
+++ b/src/wire/xsqlvar.ts
@@ -622,7 +622,7 @@ export class SQLVarInt128 extends SQLVarBase {
     decode(data: XdrReader, lowerV13: boolean, options?: NumericDecodeOptions) {
         const mode = options?.numericMode || Const.NUMERIC_MODE_LOSSY;
         const ret = mode === Const.NUMERIC_MODE_LOSSY
-            ? decodeLossyInt128(data.readInt128(), this.scale)
+            ? decodeLossyInt128(data.readInt128Signed(), this.scale)
             : decodeExactNumeric(data.readInt128Signed(), this.scale, mode);
 
         if (!lowerV13 || !data.readInt()) {

--- a/test/batch.js
+++ b/test/batch.js
@@ -93,6 +93,42 @@ describe('Batch API (op_batch_create/msg/exec, Firebird 4+)', function () {
         assert.strictEqual(rows[0].created.getTime(), created.getTime());
     });
 
+    itBatch('should preserve and consistently round fixed-point values', async function () {
+        await db.executeAsync(`RECREATE TABLE batch_numeric (
+            id INT NOT NULL PRIMARY KEY,
+            n2 NUMERIC(18,2),
+            n4 NUMERIC(18,4),
+            big BIGINT
+        )`);
+
+        const sql = 'INSERT INTO batch_numeric VALUES (?, ?, ?, ?)';
+        // op_execute is the reference for Firebird decimal conversion.
+        await db.queryAsync(sql, [1, 1.005, 1.00105, '9223372036854775807']);
+        await db.executeBatchAsync(sql, [
+            [2, 1.005, 1.00105, '9223372036854775807'],
+            [3, -1.005, -1.00105, '-9223372036854775808'],
+            [4, '90071992547409.92', '900719925474.0992', '9007199254740991'],
+        ]);
+
+        const rows = await db.queryAsync(
+            'SELECT id, CAST(n2 AS VARCHAR(40)) n2_text, ' +
+            'CAST(n4 AS VARCHAR(40)) n4_text, CAST(big AS VARCHAR(40)) big_text ' +
+            'FROM batch_numeric ORDER BY id');
+        const values = rows.map(row => ({
+            id: row.id,
+            n2: row.n2_text.trim(),
+            n4: row.n4_text.trim(),
+            big: row.big_text.trim(),
+        }));
+
+        assert.deepStrictEqual(values, [
+            { id: 1, n2: '1.01', n4: '1.0011', big: '9223372036854775807' },
+            { id: 2, n2: '1.01', n4: '1.0011', big: '9223372036854775807' },
+            { id: 3, n2: '-1.01', n4: '-1.0011', big: '-9223372036854775808' },
+            { id: 4, n2: '90071992547409.92', n4: '900719925474.0992', big: '9007199254740991' },
+        ]);
+    });
+
     itBatch('should chunk large batches into multiple op_batch_msg packets', async function () {
         const rows = [];
         for (let i = 1; i <= 120; i++) {
@@ -168,6 +204,21 @@ describe('Batch API (op_batch_create/msg/exec, Firebird 4+)', function () {
             db.executeBatchAsync(INSERT, [[1, 'a']]),
             /row 0 must be an array of 6 values/
         );
+    });
+
+    itBatch('should reject invalid fixed-point values before sending packets', async function () {
+        const created = new Date(2026, 0, 1);
+        await assert.rejects(
+            db.executeBatchAsync(INSERT, [[1, 'bad', '1oops', created, true, 1n]]),
+            /Invalid fixed-point batch value for column 3/
+        );
+        await assert.rejects(
+            db.executeBatchAsync(INSERT, [[1, 'overflow', 1, created, true, '9223372036854775808']]),
+            /Invalid fixed-point batch value for column 6/
+        );
+
+        const check = await db.queryAsync('SELECT COUNT(*) AS n FROM batch_t');
+        assert.strictEqual(check[0].n, 0);
     });
 
     itBatch('should reject string truncation server-side', async function () {

--- a/test/batch.js
+++ b/test/batch.js
@@ -129,6 +129,16 @@ describe('Batch API (op_batch_create/msg/exec, Firebird 4+)', function () {
         ]);
     });
 
+    itBatch('should round-trip signed INT128 values from regular and batch parameters', async function () {
+        await db.executeAsync('RECREATE TABLE batch_int128 (id INT PRIMARY KEY, value_i128 INT128)');
+
+        await db.queryAsync('INSERT INTO batch_int128 VALUES (?, ?)', [1, -1n]);
+        await db.executeBatchAsync('INSERT INTO batch_int128 VALUES (?, ?)', [[2, -2n]]);
+
+        const rows = await db.queryAsync('SELECT value_i128 FROM batch_int128 ORDER BY id');
+        assert.deepStrictEqual(rows.map(row => row.value_i128), [-1, -2]);
+    });
+
     itBatch('should chunk large batches into multiple op_batch_msg packets', async function () {
         const rows = [];
         for (let i = 1; i <= 120; i++) {
@@ -219,6 +229,29 @@ describe('Batch API (op_batch_create/msg/exec, Firebird 4+)', function () {
 
         const check = await db.queryAsync('SELECT COUNT(*) AS n FROM batch_t');
         assert.strictEqual(check[0].n, 0);
+    });
+
+    itBatch('should validate fixed-point values before uploading BLOBs', async function () {
+        await db.executeAsync('RECREATE TABLE batch_blob_numeric (payload BLOB, amount NUMERIC(12,2))');
+        const originalUploadBlob = db.connection.uploadBlob;
+        let uploadCount = 0;
+        db.connection.uploadBlob = function () {
+            uploadCount++;
+            return originalUploadBlob.apply(this, arguments);
+        };
+
+        try {
+            await assert.rejects(
+                db.executeBatchAsync(
+                    'INSERT INTO batch_blob_numeric VALUES (?, ?)',
+                    [[Buffer.from('must not upload'), '1oops']]
+                ),
+                /Invalid fixed-point batch value for column 2/
+            );
+            assert.strictEqual(uploadCount, 0);
+        } finally {
+            db.connection.uploadBlob = originalUploadBlob;
+        }
     });
 
     itBatch('should reject string truncation server-side', async function () {

--- a/test/unit/serialize.test.ts
+++ b/test/unit/serialize.test.ts
@@ -137,13 +137,9 @@ describe('XdrWriter / XdrReader round-trips', () => {
         const min = -(1n << 127n);
         const max = (1n << 127n) - 1n;
         const values = [min, -1n, max];
-        const buffer = Buffer.alloc(values.length * 16);
-        values.forEach((value, index) => {
-            const offset = index * 16;
-            buffer.writeBigInt64BE(value >> 64n, offset);
-            buffer.writeBigUInt64BE(value & 0xFFFFFFFFFFFFFFFFn, offset + 8);
-        });
-        const r = new XdrReader(buffer);
+        const w = new XdrWriter();
+        values.forEach(value => w.addInt128(value));
+        const r = new XdrReader(w.getData());
         expect(r.readInt128Signed()).toBe(min);
         expect(r.readInt128Signed()).toBe(-1n);
         expect(r.readInt128Signed()).toBe(max);

--- a/test/unit/xsqlvar.test.ts
+++ b/test/unit/xsqlvar.test.ts
@@ -205,6 +205,51 @@ describe('SQLParam encoding', () => {
         expect(r.readText(3, 'utf8')).toBe('abc');
     });
 
+    it('converts canonical decimal numbers to scaled coefficients with Firebird rounding', () => {
+        expect(Xsql.toScaledInteger(2.675, -2, 64)).toBe(268n);
+        expect(Xsql.toScaledInteger(1.005, -2, 64)).toBe(101n);
+        expect(Xsql.toScaledInteger(-2.675, -2, 64)).toBe(-268n);
+        expect(Xsql.toScaledInteger(-1.005, -2, 64)).toBe(-101n);
+        expect(Xsql.toScaledInteger(1.00105, -4, 64)).toBe(10011n);
+        expect(Xsql.toScaledInteger(-1.00105, -4, 64)).toBe(-10011n);
+    });
+
+    it('preserves exact string and bigint fixed-point inputs', () => {
+        expect(Xsql.toScaledInteger('900719925474.0992', -4, 64)).toBe(9007199254740992n);
+        expect(Xsql.toScaledInteger('9223372036854775807', 0, 64)).toBe(9223372036854775807n);
+        expect(Xsql.toScaledInteger('-9223372036854775808', 0, 64)).toBe(-9223372036854775808n);
+        expect(Xsql.toScaledInteger(42n, -4, 64)).toBe(420000n);
+        expect(Xsql.toScaledInteger('1.2345e2', -2, 64)).toBe(12345n);
+        expect(Xsql.toScaledInteger('.00005', -4, 64)).toBe(1n);
+        expect(Xsql.toScaledInteger('-.00005', -4, 64)).toBe(-1n);
+    });
+
+    it('supports positive scales and normalizes signed zero', () => {
+        expect(Xsql.toScaledInteger('150', 2, 64)).toBe(2n);
+        expect(Xsql.toScaledInteger('-150', 2, 64)).toBe(-2n);
+        expect(Xsql.toScaledInteger('149', 2, 64)).toBe(1n);
+        expect(Xsql.toScaledInteger(-0, -4, 64)).toBe(0n);
+    });
+
+    it('validates fixed-point input syntax, finiteness, exponents, and signed ranges', () => {
+        expect(() => Xsql.toScaledInteger(Number.NaN, -2, 64)).toThrow(/finite/);
+        expect(() => Xsql.toScaledInteger(Number.POSITIVE_INFINITY, -2, 64)).toThrow(/finite/);
+        expect(() => Xsql.toScaledInteger(1, Number.MAX_VALUE, 64)).toThrow(/scale/);
+        expect(() => Xsql.toScaledInteger('1oops', -2, 64)).toThrow(/Invalid fixed-point/);
+        expect(() => Xsql.toScaledInteger('', -2, 64)).toThrow(/Invalid fixed-point/);
+        expect(() => Xsql.toScaledInteger('1e999999999999999999999', -2, 64)).toThrow(/exponent/);
+
+        expect(Xsql.toScaledInteger('327.67', -2, 16)).toBe(32767n);
+        expect(Xsql.toScaledInteger('-327.68', -2, 16)).toBe(-32768n);
+        expect(() => Xsql.toScaledInteger('327.675', -2, 16)).toThrow(/signed 16-bit range/);
+        expect(() => Xsql.toScaledInteger('-327.685', -2, 16)).toThrow(/signed 16-bit range/);
+        expect(() => Xsql.toScaledInteger('2147483648', 0, 32)).toThrow(/signed 32-bit range/);
+        expect(() => Xsql.toScaledInteger('9223372036854775808', 0, 64)).toThrow(/signed 64-bit range/);
+        expect(Xsql.toScaledInteger(-(1n << 127n), 0, 128)).toBe(-(1n << 127n));
+        expect(Xsql.toScaledInteger((1n << 127n) - 1n, 0, 128)).toBe((1n << 127n) - 1n);
+        expect(() => Xsql.toScaledInteger(1n << 127n, 0, 128)).toThrow(/signed 128-bit range/);
+    });
+
     it('SQLParamQuad encodes blob ids', () => {
         const r = reader(w => new Xsql.SQLParamQuad({ high: 1, low: 2 }).encode(w));
         expect(r.readInt()).toBe(1);

--- a/test/unit/xsqlvar.test.ts
+++ b/test/unit/xsqlvar.test.ts
@@ -101,6 +101,7 @@ describe('SQLVar decoding (protocol 13+, lowerV13=false)', () => {
         const v = new Xsql.SQLVarInt128();
         v.scale = -2;
         expect(v.decode(reader(w => w.addInt128(12345n)), false)).toBe(123.45);
+        expect(v.decode(reader(w => w.addInt128(-12345n)), false)).toBe(-123.45);
     });
 
     it('safe mode formats signed INT128 values exactly', () => {


### PR DESCRIPTION
## Summary

Fixes scaled numeric parameter encoding for the Firebird 4+ batch API, together with the signed INT128 wire handling needed for negative values to round-trip correctly.

Batch execution must encode values according to the prepared statement metadata before sending them on the wire. The previous `parseFloat` / `Math.round` path could lose precision for exact decimal strings, round decimal ties incorrectly because of binary floating-point representation, round negative ties asymmetrically, and partially accept malformed numeric strings.

## Changes

- Parse finite `number`, decimal `string`, and `bigint` batch values into an exact scaled integer coefficient.
- Round discarded decimal digits to nearest, with ties away from zero, matching Firebird numeric conversion behavior.
- Preserve exact string and BigInt inputs without passing them through `Number`.
- Validate the physical signed range for SMALLINT, INTEGER, INT64, and INT128 before encoding.
- Validate fixed-point values before starting the BLOB upload pre-pass.
- Reject malformed and non-finite values before any batch-related wire traffic.
- Encode the high word of negative INT128 values as signed two's complement.
- Decode INT128 through the signed reader in every numeric mode.
- Document the accepted batch input forms and the precision limitation of unsafe JavaScript numbers.

The exact metadata-directed decimal conversion is limited to the Firebird 4+ batch path. The shared INT128 writer/reader corrections also allow negative BigInt parameters sent through regular query/execute to round-trip with the correct sign.

## Examples covered

- `2.675` at scale 2 becomes `2.68` rather than `2.67`.
- `-2.675` becomes `-2.68`.
- `1.00105` at scale 4 becomes `1.0011`.
- Exact unsafe strings such as `900719925474.0992` retain every digit.
- INT64 minima/maxima and signed INT128 extrema encode correctly.

## Validation

- Build and typecheck pass.
- Unit and full local Firebird 3 suites pass.
- The complete 16-job matrix across Node 20/22/24/26 and Firebird 3/4/5/6-snapshot passed on the source branch before the review follow-up.
- Firebird 4+ integration tests compare batch results with normal `op_execute`, cover exact unsafe scaled strings, INT64 extrema, signed INT128 regular/batch round trips, and mixed BLOB/numeric validation ordering.
- Invalid and overflow inputs fail before packet transmission while leaving the connection usable.